### PR TITLE
[dunfell] strongswan: Make PACKAGECONFIG a default value

### DIFF
--- a/meta-networking/recipes-support/strongswan/strongswan_5.8.4.bb
+++ b/meta-networking/recipes-support/strongswan/strongswan_5.8.4.bb
@@ -24,7 +24,7 @@ EXTRA_OECONF = " \
 
 EXTRA_OECONF += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--with-systemdsystemunitdir=${systemd_unitdir}/system/', '--without-systemdsystemunitdir', d)}"
 
-PACKAGECONFIG ??= "charon curl gmp openssl stroke sqlite3 \
+PACKAGECONFIG ?= "charon curl gmp openssl stroke sqlite3 \
         ${@bb.utils.filter('DISTRO_FEATURES', 'ldap', d)} \
 "
 PACKAGECONFIG[aesni] = "--enable-aesni,--disable-aesni,,${PN}-plugin-aesni"


### PR DESCRIPTION
Change from a weak default to a default in the definition of the PACKAGECONFIG.

In https://github.com/flihp/meta-measured/blob/master/networking-layer/recipes-support/strongswan/strongswan_5.%25.bbappend the PACKAGECONFIG is appended to, so if the definition is weak here, the variable will be empty when the bbappend attempts to add to it.

Also have a pull request open on master: https://github.com/openembedded/meta-openembedded/pull/340