### PR TITLE
python-pycares: Add dependency on cffi-native

### DIFF
--- a/meta-python/recipes-devtools/python/python-pycares.inc
+++ b/meta-python/recipes-devtools/python/python-pycares.inc
@@ -9,6 +9,9 @@ SRC_URI[sha256sum] = "663c000625725d3a63466a674df4ee7f62bf8ca1ae8a0b87a6411eb811
 
 PYPI_PACKAGE = "pycares"
 inherit pypi
+
+DEPENDS += "${PYTHON_PN}-cffi-native"
+
 RDEPENDS_${PN} = "\
     ${PYTHON_PN}-cffi \
     ${PYTHON_PN}-idna \


### PR DESCRIPTION
The python3-pycares recipe was added by NI because it was needed by NI's
implementation of salt-minion. When building with MACHINE=xilinx-zynq,
the python3-pycares recipe will throw an error during do_compile, that
the cffi library is the wrong ELFCLASS. That's because it is trying to
link against the cffi-native x64 library.

Fix that error by asserting a DEPENDS on `python3-cffi-native`, so that
ARM builds will use the correct ELFCLASS.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Maintainership
This change was already made [in hardknott](https://github.com/ni/meta-openembedded/commit/27754ac6cadd53bbeef973eecbbb6adb4a1cd001), so does not need to be ported.

# Testing
* `python3-pycares` now compiles on my dev machine, @billpittman 's dev machine, and @jeminor 's dev machine.

@ni/rtos 