### PR TITLE
opencv: Remove PV to reduce ipk length

### DIFF
--- a/meta-oe/recipes-support/opencv/opencv_3.3.bb
+++ b/meta-oe/recipes-support/opencv/opencv_3.3.bb
@@ -61,7 +61,6 @@ SRC_URI = "git://github.com/opencv/opencv.git;name=opencv \
     file://protobuf.patch \
     file://already-exists.patch \
 "
-PV = "3.3+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Since PV contained hashes from 5 git repos, package name and thereby the
export path was too long causing build failure in CI.

Removed explicit definition of PV so that default gets used - hardknott
does the same

### Testing
Verified locally built ipks don't have git hashes anymore

### Note
If we are able to fix the max path length at source, will revert this change.
This is a hot fix to get CI passing.

@ni/rtos 