### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/meta-filesystems/recipes-filesystems/logfsprogs/logfsprogs_git.bb
+++ b/meta-filesystems/recipes-filesystems/logfsprogs/logfsprogs_git.bb
@@ -11,7 +11,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://fsck.c;md5=3859dc73da97909ff1d0125e88a27e02"
 DEPENDS = "zlib"
 
-SRC_URI = "git://github.com/prasad-joshi/logfsprogs.git \
+SRC_URI = "git://github.com/prasad-joshi/logfsprogs.git;protocol=https \
            file://0001-Add-LDFLAGS-to-linker-cmdline.patch \
            file://0001-btree-Avoid-conflicts-with-libc-namespace-about-setk.patch \
            "

--- a/meta-filesystems/recipes-filesystems/sshfs-fuse/sshfs-fuse_2.8.bb
+++ b/meta-filesystems/recipes-filesystems/sshfs-fuse/sshfs-fuse_2.8.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv2"
 DEPENDS = "glib-2.0 fuse"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/libfuse/sshfs;tag=b2fa7593586b141298e6159f40f521d2b0f4f894 \
+SRC_URI = "git://github.com/libfuse/sshfs;tag=b2fa7593586b141298e6159f40f521d2b0f4f894;protocol=https \
            file://0001-Makefile-fix-path-for-sshfs.1.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-filesystems/recipes-filesystems/unionfs-fuse/unionfs-fuse_2.0.bb
+++ b/meta-filesystems/recipes-filesystems/unionfs-fuse/unionfs-fuse_2.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/unionfs.c;beginline=3;endline=8;md5=30fa8de70fd8a
                     file://LICENSE;md5=7e5a37fce17307066eec6b23546da3b3 \
 "
 
-SRC_URI = "git://github.com/rpodgorny/${BPN}.git;branch=master \
+SRC_URI = "git://github.com/rpodgorny/${BPN}.git;branch=master;protocol=https \
            file://0001-support-cross-compiling.patch \
            file://0001-unionfs-Define-IOCPARM_LEN-if-undefined.patch \
            "

--- a/meta-gnome/recipes-gnome/metacity/metacity_3.38.0.bb
+++ b/meta-gnome/recipes-gnome/metacity/metacity_3.38.0.bb
@@ -12,7 +12,7 @@ inherit autotools gettext gnomebase distro_features_check
 # depends on startup-notification which depends on virtual/libx11
 REQUIRED_DISTRO_FEATURES = "x11"
 
-SRC_URI = "git://github.com/GNOME/metacity.git;branch=master \
+SRC_URI = "git://github.com/GNOME/metacity.git;branch=master;protocol=https \
            file://0001-drop-zenity-detection.patch \
 "
 

--- a/meta-gnome/recipes-support/keybinder/keybinder_3.0.bb
+++ b/meta-gnome/recipes-support/keybinder/keybinder_3.0.bb
@@ -13,7 +13,7 @@ B = "${S}"
 
 SRCREV = "736ccef40d39603b8111c8a3a0bca0319bbafdc0"
 PV = "3.0+git${SRCPV}"
-SRC_URI = "git://github.com/engla/keybinder.git;branch=keybinder-3.0 \
+SRC_URI = "git://github.com/engla/keybinder.git;branch=keybinder-3.0;protocol=https \
 "
 
 RDEPENDS_${PN} = "gtk+"

--- a/meta-initramfs/recipes-bsp/kexecboot/kexecboot_git.bb
+++ b/meta-initramfs/recipes-bsp/kexecboot/kexecboot_git.bb
@@ -38,7 +38,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 PV = "0.6+git${SRCPV}"
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/kexecboot/kexecboot.git"
+SRC_URI = "git://github.com/kexecboot/kexecboot.git;protocol=https"
 SRCREV = "4c4f127e79ac5b8d6b6e2fbb938ccbf12b04c531"
 inherit autotools
 

--- a/meta-multimedia/recipes-mediacenter/kodi/jsonschemabuilder-native.bb
+++ b/meta-multimedia/recipes-mediacenter/kodi/jsonschemabuilder-native.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://JsonSchemaBuilder.cpp;beginline=2;endline=18;md5=1f67
 SRCREV = "661dd08d221f5b2bf509a696a6aca5ee7d45bb27"
 
 PV = "17.1+gitr${SRCPV}"
-SRC_URI = "git://github.com/xbmc/xbmc.git;branch=Krypton"
+SRC_URI = "git://github.com/xbmc/xbmc.git;branch=Krypton;protocol=https"
 
 inherit autotools-brokensep gettext native
 

--- a/meta-multimedia/recipes-mediacenter/kodi/kodi_17.bb
+++ b/meta-multimedia/recipes-mediacenter/kodi/kodi_17.bb
@@ -65,7 +65,7 @@ PROVIDES = "xbmc"
 SRCREV = "6abeebd5ba371547c8f04272296433f5e4e28e86"
 PV = "17.3+gitr${SRCPV}"
 ADDONSPV = "17.1"
-SRC_URI = "git://github.com/xbmc/xbmc.git;branch=Krypton \
+SRC_URI = "git://github.com/xbmc/xbmc.git;branch=Krypton;protocol=https \
     https://repo.voidlinux.eu/distfiles/${BPN}-${ADDONSPV}-generated-addons.tar.xz;name=addons;unpack=0 \
     file://0003-configure-don-t-try-to-run-stuff-to-find-tinyxml.patch \
     file://0004-handle-SIGTERM.patch \

--- a/meta-multimedia/recipes-multimedia/dca/dcadec_0.2.0.bb
+++ b/meta-multimedia/recipes-multimedia/dca/dcadec_0.2.0.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING.LGPLv2.1;md5=4fbd65380cdd255951079008b364516c"
 
 SRCREV = "b93deed1a231dd6dd7e39b9fe7d2abe05aa00158"
-SRC_URI = "git://github.com/foo86/dcadec.git;protocol=http"
+SRC_URI = "git://github.com/foo86/dcadec.git;protocol=http;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-connector-dbus_0.3.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-connector-dbus_0.3.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 
 DEPENDS = "glib-2.0 dbus dleyna-core"
 
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;protocol=https"
 SRCREV = "de913c35e5c936e2d40ddbd276ee902cd802bd3a"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-core_0.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-core_0.6.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 
 DEPENDS = "glib-2.0 gupnp"
 
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;protocol=https"
 SRCREV = "27a3786ec013f64fd58243410a60798f824acec3"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-renderer_0.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-renderer_0.6.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 DEPENDS = "glib-2.0 gssdp gupnp gupnp-av gupnp-dlna libsoup-2.4 dleyna-core"
 RDEPENDS_${PN} = "dleyna-connector-dbus"
 
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;protocol=https"
 SRCREV = "50fd1ec9d51328e7dea98874129dc8d6fe3ea1dd"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/dleyna/dleyna-server_0.6.0.bb
+++ b/meta-multimedia/recipes-multimedia/dleyna/dleyna-server_0.6.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 DEPENDS = "glib-2.0 gssdp gupnp gupnp-av gupnp-dlna libsoup-2.4 libxml2 dleyna-core"
 RDEPENDS_${PN} = "dleyna-connector-dbus"
 
-SRC_URI = "git://github.com/01org/${BPN}.git"
+SRC_URI = "git://github.com/01org/${BPN}.git;protocol=https"
 SRCREV = "776950d5d96ac9dbf5c5c47bde8ac06f50a3cf46"
 S = "${WORKDIR}/git"
 

--- a/meta-multimedia/recipes-multimedia/fluidsynth/fluidsynth_1.1.10.bb
+++ b/meta-multimedia/recipes-multimedia/fluidsynth/fluidsynth_1.1.10.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fc178bcd425090939a8b634d1d6a9594"
 DEPENDS = "alsa-lib ncurses glib-2.0"
 
 SRC_URI = " \
-    git://github.com/FluidSynth/fluidsynth.git;branch=1.1.x \
+    git://github.com/FluidSynth/fluidsynth.git;branch=1.1.x;protocol=https \
     file://0001-Use-ARM-NEON-accelaration-for-float-multithreaded-se.patch \
 "
 SRCREV = "f5a0fee6f7f2b2ab4c866df1acb649333464b3fd"

--- a/meta-multimedia/recipes-multimedia/musicbrainz/libmusicbrainz_git.bb
+++ b/meta-multimedia/recipes-multimedia/musicbrainz/libmusicbrainz_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "expat libxml2 libxml2-native neon neon-native"
 PV = "5.1.0+git${SRCPV}"
 
 SRCREV = "44c05779dd996035758f5ec426766aeedce29cc3"
-SRC_URI = "git://github.com/metabrainz/libmusicbrainz.git \
+SRC_URI = "git://github.com/metabrainz/libmusicbrainz.git;protocol=https \
            file://allow-libdir-override.patch "
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-connectivity/dibbler/dibbler_git.bb
+++ b/meta-networking/recipes-connectivity/dibbler/dibbler_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7236695bb6d4461c105d685a8b61c4e3"
 
 SRCREV = "c4b0ed52e751da7823dd9a36e91f93a6310e5525"
 
-SRC_URI = "git://github.com/tomaszmrugalski/dibbler \
+SRC_URI = "git://github.com/tomaszmrugalski/dibbler;protocol=https \
            file://dibbler_fix_getSize_crash.patch \
           "
 PV = "1.0.1+1.0.2RC1+git${SRCREV}"

--- a/meta-networking/recipes-connectivity/libdnet/libdnet_1.12.bb
+++ b/meta-networking/recipes-connectivity/libdnet/libdnet_1.12.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0036c1b155f4e999f3e0a373490b5db9"
 
-SRC_URI = "git://github.com/dugsong/libdnet.git;nobranch=1"
+SRC_URI = "git://github.com/dugsong/libdnet.git;nobranch=1;protocol=https"
 SRCREV = "12fca29a6d4e99d1b923d6820887fe7b24226904"
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-connectivity/vpnc/vpnc_0.5.3.bb
+++ b/meta-networking/recipes-connectivity/vpnc/vpnc_0.5.3.bb
@@ -9,7 +9,7 @@ DEPENDS += "libgcrypt"
 
 PV .= "r550-2jnpr1"
 SRCREV = "b1243d29e0c00312ead038b04a2cf5e2fa31d740"
-SRC_URI = "git://github.com/ndpgroup/vpnc \
+SRC_URI = "git://github.com/ndpgroup/vpnc;protocol=https \
            file://long-help \
            file://default.conf \
            file://0001-search-for-log-help-in-build-dir.patch \

--- a/meta-networking/recipes-daemons/iscsi-initiator-utils/iscsi-initiator-utils_2.0.876.bb
+++ b/meta-networking/recipes-daemons/iscsi-initiator-utils/iscsi-initiator-utils_2.0.876.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
 SRCREV ?= "24580adc4c174bbc5dde3ae7594a46d57635e906"
 
-SRC_URI = "git://github.com/open-iscsi/open-iscsi \
+SRC_URI = "git://github.com/open-iscsi/open-iscsi;protocol=https \
     file://initd.debian \
     file://99_iscsi-initiator-utils \
     file://iscsi-initiator \

--- a/meta-networking/recipes-irc/znc/znc_git.bb
+++ b/meta-networking/recipes-irc/znc/znc_git.bb
@@ -7,8 +7,8 @@ DEPENDS = "openssl zlib icu"
 
 PV = "1.6.0"
 
-SRC_URI = "git://github.com/znc/znc.git;name=znc \
-           git://github.com/jimloco/Csocket.git;destsuffix=git/third_party/Csocket;name=Csocket \
+SRC_URI = "git://github.com/znc/znc.git;name=znc;protocol=https \
+           git://github.com/jimloco/Csocket.git;destsuffix=git/third_party/Csocket;name=Csocket;protocol=https \
           "
 SRCREV_znc = "f47e8465efa4e1cd948b9caae93ac401b4355df8"
 SRCREV_Csocket = "07b4437396122650e5b8fb3d014e820a5decf4ee"

--- a/meta-networking/recipes-protocols/xl2tpd/xl2tpd.inc
+++ b/meta-networking/recipes-protocols/xl2tpd/xl2tpd.inc
@@ -8,7 +8,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/xelerance/xl2tpd.git \
+SRC_URI = "git://github.com/xelerance/xl2tpd.git;protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-support/c-ares/c-ares_1.13.0.bb
+++ b/meta-networking/recipes-support/c-ares/c-ares_1.13.0.bb
@@ -8,7 +8,7 @@ SRCREV = "3be1924221e1326df520f8498d704a5c4c8d0cce"
 PV = "1.13.0+gitr${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/c-ares/c-ares.git \
+    git://github.com/c-ares/c-ares.git;protocol=https \
     file://cmake-install-libcares.pc.patch \
 "
 

--- a/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb
+++ b/meta-networking/recipes-support/curlpp/curlpp_0.8.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 DEPENDS = "curl"
 DEPENDS_class-native = "curl-native"
 
-SRC_URI = "git://github.com/jpbarrette/curlpp.git"
+SRC_URI = "git://github.com/jpbarrette/curlpp.git;protocol=https"
 
 SRCREV = "592552a165cc569dac7674cb7fc9de3dc829906f"
 

--- a/meta-networking/recipes-support/dnssec-conf/dnssec-conf_2.02.bb
+++ b/meta-networking/recipes-support/dnssec-conf/dnssec-conf_2.02.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=0636e73ff0215e8d672dc4c32c317bb3"
 DEPENDS += "xmlto-native docbook-xml-dtd4-native \
             docbook-xsl-stylesheets-native libxslt-native"
 
-SRC_URI = "git://github.com/xelerance/dnssec-conf.git"
+SRC_URI = "git://github.com/xelerance/dnssec-conf.git;protocol=https"
 SRCREV = "8e799683736b4a7b5e5e78f98fba0a6f48393537"
 
 S = "${WORKDIR}/git"

--- a/meta-networking/recipes-support/geoip/geoip_1.6.11.bb
+++ b/meta-networking/recipes-support/geoip/geoip_1.6.11.bb
@@ -8,7 +8,7 @@ using reverse DNS lookups."
 HOMEPAGE = "http://dev.maxmind.com/geoip/"
 SECTION = "libdevel"
 
-SRC_URI = "git://github.com/maxmind/geoip-api-c.git \
+SRC_URI = "git://github.com/maxmind/geoip-api-c.git;protocol=https \
            http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz;apply=no;name=GeoIP-dat \
            http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz;apply=no;name=GeoIPv6-dat \
            http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz;apply=no;name=GeoLiteCity-dat \

--- a/meta-networking/recipes-support/lksctp-tools/lksctp-tools_1.0.17.bb
+++ b/meta-networking/recipes-support/lksctp-tools/lksctp-tools_1.0.17.bb
@@ -14,7 +14,7 @@ PV .= "+git${SRCPV}"
 LK_REL = "1.0.17"
 
 SRC_URI = " \
-    git://github.com/sctp/lksctp-tools.git \
+    git://github.com/sctp/lksctp-tools.git;protocol=https \
     file://run-ptest \
     file://v4test.sh \
     file://v6test.sh \

--- a/meta-networking/recipes-support/lowpan-tools/lowpan-tools_git.bb
+++ b/meta-networking/recipes-support/lowpan-tools/lowpan-tools_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 DEPENDS = "flex-native bison-native libnl python"
 
 PV = "0.3.1+git${SRCPV}"
-SRC_URI = "git://github.com/linux-wpan/lowpan-tools \
+SRC_URI = "git://github.com/linux-wpan/lowpan-tools;protocol=https \
            file://no-help2man.patch \
            file://0001-Fix-build-errors-with-clang.patch \
            file://0001-addrdb-coord-config-parse.y-add-missing-time.h-inclu.patch \

--- a/meta-networking/recipes-support/mtr/mtr_0.87.bb
+++ b/meta-networking/recipes-support/mtr/mtr_0.87.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
 PV .= "+git${SRCPV}"
 
 SRCREV = "e6d0a7e93129e8023654ebf58dfa8135d1b1af56"
-SRC_URI = "git://github.com/traviscross/mtr"
+SRC_URI = "git://github.com/traviscross/mtr;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/netperf/netperf_git.bb
+++ b/meta-networking/recipes-support/netperf/netperf_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a0ab17253e7a3f318da85382c7d5d5d6"
 
 PV = "2.7.0+git${SRCPV}"
 
-SRC_URI="git://github.com/HewlettPackard/netperf.git \
+SRC_URI="git://github.com/HewlettPackard/netperf.git;protocol=https \
          file://cpu_set.patch \
          file://vfork.patch \
          file://init"

--- a/meta-networking/recipes-support/nis/yp-tools_4.2.3.bb
+++ b/meta-networking/recipes-support/nis/yp-tools_4.2.3.bb
@@ -14,7 +14,7 @@ and ypdomainname. \
 # v4.2.3
 SRCREV = "1bfda29c342a81b97cb1995ffd9e8da5de63e7ab"
 
-SRC_URI = "git://github.com/thkukuk/yp-tools \
+SRC_URI = "git://github.com/thkukuk/yp-tools;protocol=https \
            file://domainname.service \
            "
 

--- a/meta-networking/recipes-support/ntimed/ntimed_git.bb
+++ b/meta-networking/recipes-support/ntimed/ntimed_git.bb
@@ -8,7 +8,7 @@ SECTION = "net"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://main.c;beginline=2;endline=24;md5=89db8e76f2951f3fad167e7aa9718a44"
 
-SRC_URI = "git://github.com/bsdphk/Ntimed \
+SRC_URI = "git://github.com/bsdphk/Ntimed;protocol=https \
            file://use-ldflags.patch"
 
 PV = "0.0+git${SRCPV}"

--- a/meta-networking/recipes-support/open-isns/open-isns_0.97.bb
+++ b/meta-networking/recipes-support/open-isns/open-isns_0.97.bb
@@ -13,7 +13,7 @@ SECTION = "net"
 
 DEPENDS = "openssl"
 
-SRC_URI = "git://github.com/open-iscsi/open-isns \
+SRC_URI = "git://github.com/open-iscsi/open-isns;protocol=https \
            file://0001-util.h-endian.h-is-available-on-musl-on-linux.patch \
            "
 

--- a/meta-networking/recipes-support/phytool/phytool.bb
+++ b/meta-networking/recipes-support/phytool/phytool.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=39bba7d2cf0ba1036f2a6e2be52fe3f0"
 
 PV = "1.0.1+git${SRCPV}"
 SRCREV = "3149bfdb4f513e2f0da0a7d0bc5d0873578696f2"
-SRC_URI = "git://github.com/wkz/phytool.git"
+SRC_URI = "git://github.com/wkz/phytool.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/rdma-core/rdma-core_28.0.bb
+++ b/meta-networking/recipes-support/rdma-core/rdma-core_28.0.bb
@@ -6,7 +6,7 @@ DEPENDS = "libnl"
 RDEPENDS_${PN} = "bash perl"
 
 BRANCH = "stable-v${@d.getVar('PV').split('.')[0]}"
-SRC_URI = "git://github.com/linux-rdma/rdma-core.git;branch=${BRANCH} \
+SRC_URI = "git://github.com/linux-rdma/rdma-core.git;branch=${BRANCH};protocol=https \
            file://0001-Remove-man-files-which-cant-be-built.patch \
            "
 SRCREV = "f12c953f0864691eacc9fcc4cda489b92ffd5a85"

--- a/meta-networking/recipes-support/smcroute/smcroute_2.0.0.bb
+++ b/meta-networking/recipes-support/smcroute/smcroute_2.0.0.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4325afd396febcb659c36b49533135d4"
 
 SRCREV = "d6280e64b27d5a4bd7f37dac36b455f4ae5f9ab3"
-SRC_URI = "git://github.com/troglobit/smcroute.git;branch=master;protocol=git"
+SRC_URI = "git://github.com/troglobit/smcroute.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-support/wpan-tools/wpan-tools_git.bb
+++ b/meta-networking/recipes-support/wpan-tools/wpan-tools_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4cfd939b1d7e6aba9fcefb7f6e2fd45d"
 DEPENDS = "libnl"
 
 PV = "0.8+git${SRCPV}"
-SRC_URI = "git://github.com/linux-wpan/wpan-tools \
+SRC_URI = "git://github.com/linux-wpan/wpan-tools;protocol=https \
            "
 SRCREV = "3f473f5136f89773997cb4fff2d8ed647734e2f5"
 

--- a/meta-oe/recipes-benchmark/iperf3/iperf3_3.2.bb
+++ b/meta-oe/recipes-benchmark/iperf3/iperf3_3.2.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=d098223e44bdd19585315ee75cd9d2d7"
 
 DEPENDS = "openssl"
 
-SRC_URI = "git://github.com/esnet/iperf.git \
+SRC_URI = "git://github.com/esnet/iperf.git;protocol=https \
            file://automake-foreign.patch \
            file://0002-Remove-pg-from-profile_CFLAGS.patch \
            "

--- a/meta-oe/recipes-benchmark/tinymembench/tinymembench_git.bb
+++ b/meta-oe/recipes-benchmark/tinymembench/tinymembench_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://main.c;endline=22;md5=879b9bbb60851454885b5fa47eb6b34
 PV = "0.4.0+git${SRCPV}"
 
 SRCREV = "2c789849709d837b4bd114c11ed2d9bdc65afbc6"
-SRC_URI = "git://github.com/ssvb/tinymembench.git"
+SRC_URI = "git://github.com/ssvb/tinymembench.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-bsp/cpufrequtils/cpufrequtils_008.bb
+++ b/meta-oe/recipes-bsp/cpufrequtils/cpufrequtils_008.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 SRCREV = "a2f0c39d5f21596bb9f5223e895c0ff210b265d0"
 # SRC_URI = "git://git.kernel.org/pub/scm/utils/kernel/cpufreq/cpufrequtils.git
 
-SRC_URI = "git://github.com/emagii/cpufrequtils.git \
+SRC_URI = "git://github.com/emagii/cpufrequtils.git;protocol=https \
            file://0001-dont-unset-cflags.patch \
 "
 

--- a/meta-oe/recipes-bsp/edac-utils/edac-utils_git.bb
+++ b/meta-oe/recipes-bsp/edac-utils/edac-utils_git.bb
@@ -11,7 +11,7 @@ PV = "0.18+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/grondo/edac-utils \
+SRC_URI = "git://github.com/grondo/edac-utils;protocol=https \
     file://make-init-script-be-able-to-automatically-load-EDAC-.patch \
     file://add-restart-to-initscript.patch \
     file://edac.service \

--- a/meta-oe/recipes-bsp/efivar/efivar_37.bb
+++ b/meta-oe/recipes-bsp/efivar/efivar_37.bb
@@ -13,7 +13,7 @@ inherit pkgconfig
 COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
 
 SRCREV = "c1d6b10e1ed4ba2be07f385eae5bceb694478a10"
-SRC_URI = "git://github.com/rhinstaller/efivar.git \
+SRC_URI = "git://github.com/rhinstaller/efivar.git;protocol=https \
            file://allow-multi-definitions-for-native.patch \
            "
 SRC_URI_append_class-target = " file://0001-efivar-fix-for-cross-compile.patch \

--- a/meta-oe/recipes-bsp/tbtadm/tbtadm_0.9.3.bb
+++ b/meta-oe/recipes-bsp/tbtadm/tbtadm_0.9.3.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} = "boost-filesystem"
 inherit cmake
 
 SRCREV = "fe0fa2237b971ec8baae36b785d98a772684e5e7"
-SRC_URI = "git://github.com/intel/thunderbolt-software-user-space.git \
+SRC_URI = "git://github.com/intel/thunderbolt-software-user-space.git;protocol=https \
            file://0001-tbtadm-Disable-manpage-target.patch \
            "
 

--- a/meta-oe/recipes-connectivity/libndp/libndp_1.6.bb
+++ b/meta-oe/recipes-connectivity/libndp/libndp_1.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://libndp.org/"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/jpirko/libndp \
+SRC_URI = "git://github.com/jpirko/libndp;protocol=https \
            file://0001-include-sys-select.h-for-fd_-definitions.patch \
            "
 # tag for v1.6

--- a/meta-oe/recipes-connectivity/libtorrent/libtorrent_git.bb
+++ b/meta-oe/recipes-connectivity/libtorrent/libtorrent_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=393a5ca445f6965873eca0259a17f833"
 
 DEPENDS = "zlib libsigc++-2.0 openssl cppunit"
 
-SRC_URI = "git://github.com/rakshasa/libtorrent \
+SRC_URI = "git://github.com/rakshasa/libtorrent;protocol=https \
            file://don-t-run-code-while-configuring-package.patch \
            file://0001-implement-64bit-atomic-for-mips.patch \
            file://0001-Define-64bit-atomic-helpers-for-ppc-32-bit.patch \

--- a/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.2.0.bb
+++ b/meta-oe/recipes-connectivity/paho-mqtt-c/paho-mqtt-c_1.2.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = " \
         file://about.html;md5=dcde438d73cf42393da9d40fabc0c9bc \
 "
 
-SRC_URI = "git://github.com/eclipse/paho.mqtt.c;protocol=http"
+SRC_URI = "git://github.com/eclipse/paho.mqtt.c;protocol=http;protocol=https"
 
 SRCREV = "e8d34da24ad807f5e698b327d67591fd4b4bfa7e"
 

--- a/meta-oe/recipes-connectivity/rabbitmq-c/rabbitmq-c_0.7.0.bb
+++ b/meta-oe/recipes-connectivity/rabbitmq-c/rabbitmq-c_0.7.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/alanxz/rabbitmq-c"
 LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=6b7424f9db80cfb11fdd5c980b583f53"
 LICENSE = "MIT"
 
-SRC_URI = "git://github.com/alanxz/rabbitmq-c.git"
+SRC_URI = "git://github.com/alanxz/rabbitmq-c.git;protocol=https"
 SRCREV = "4dde30ce8d984edda540349f57eb7995a87ba9de"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-connectivity/rtorrent/rtorrent_git.bb
+++ b/meta-oe/recipes-connectivity/rtorrent/rtorrent_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 DEPENDS = "libsigc++-2.0 curl cppunit libtorrent ncurses"
 
-SRC_URI = "git://github.com/rakshasa/rtorrent \
+SRC_URI = "git://github.com/rakshasa/rtorrent;protocol=https \
     file://don-t-run-code-while-configuring-package.patch \
 "
 SRCREV = "226e670decf92e7adaa845a6982aca4f164ea740"

--- a/meta-oe/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/meta-oe/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "libnl"
 PV = "0.1+gitr${SRCPV}"
 
 SRCREV = "b03d9ce6362e6d22d6929f2736409af3b0fd3c88"
-SRC_URI = "git://github.com/TI-OpenLink/ti-utils.git;branch=r5-jb"
+SRC_URI = "git://github.com/TI-OpenLink/ti-utils.git;branch=r5-jb;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-connectivity/umip/umip_1.0.bb
+++ b/meta-oe/recipes-connectivity/umip/umip_1.0.bb
@@ -9,7 +9,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=073dc31ccb2ebed70db54f1e8aeb4c33"
 DEPENDS = "rpm indent-native"
 
-SRC_URI = "git://github.com/jlanza/umip \
+SRC_URI = "git://github.com/jlanza/umip;protocol=https \
            file://add-dependency-to-support-parallel-compilation.patch \
            file://mip6d \
            file://mip6d.service \

--- a/meta-oe/recipes-connectivity/zeromq/cppzmq_git.bb
+++ b/meta-oe/recipes-connectivity/zeromq/cppzmq_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "zeromq"
 SRCREV = "6aa3ab686e916cb0e62df7fa7d12e0b13ae9fae6"
 PV = "4.2.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/zeromq/cppzmq.git"
+SRC_URI = "git://github.com/zeromq/cppzmq.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-core/dbus/dbus-broker_git.bb
+++ b/meta-oe/recipes-core/dbus/dbus-broker_git.bb
@@ -11,7 +11,7 @@ DEPENDS = "dbus glib-2.0 expat"
 PV = "9+git${SRCPV}"
 SRCREV = "ccd06b284892182af569e69046262331150e3536"
 
-SRC_URI = "git://github.com/bus1/dbus-broker;protocol=git"
+SRC_URI = "git://github.com/bus1/dbus-broker;protocol=https"
 SRC_URI += "file://0001-Comment-rst2man-related-stuff.patch"
 SRC_URI += "file://0002-Correct-including-directory-for-conf.patch"
 

--- a/meta-oe/recipes-core/dbus/dbus-daemon-proxy_git.bb
+++ b/meta-oe/recipes-core/dbus/dbus-daemon-proxy_git.bb
@@ -6,7 +6,7 @@ SRCREV = "1226a0a1374628ff191f6d8a56000be5e53e7608"
 PV = "0.0.0+gitr${SRCPV}"
 PR = "r1.59"
 
-SRC_URI = "git://github.com/alban/dbus-daemon-proxy \
+SRC_URI = "git://github.com/alban/dbus-daemon-proxy;protocol=https \
            file://0001-dbus-daemon-proxy-Return-DBUS_HANDLER_RESULT_NOT_YET.patch \
            "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-crypto/engine-pkcs11/engine-pkcs11_0.2.2.bb
+++ b/meta-oe/recipes-crypto/engine-pkcs11/engine-pkcs11_0.2.2.bb
@@ -9,7 +9,7 @@ LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://src/engine_pkcs11.h;beginline=1;endline=26;md5=973a19f8a6105de047f2adfbbfc04c33"
 DEPENDS = "openssl libp11"
 
-SRC_URI = "git://github.com/OpenSC/engine_pkcs11.git"
+SRC_URI = "git://github.com/OpenSC/engine_pkcs11.git;protocol=https"
 SRCREV = "132fcf2c8b319f9f4b2ebdc8dcb54ff496dc0519"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-crypto/pkcs11-helper/pkcs11-helper_1.11.bb
+++ b/meta-oe/recipes-crypto/pkcs11-helper/pkcs11-helper_1.11.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = " \
     file://COPYING.GPL;md5=8a71d0475d08eee76d8b6d0c6dbec543 \
     file://COPYING.BSD;md5=f79f90ea7a106796af80b5d05f1f8da1 \
 "
-SRC_URI = "git://github.com/OpenSC/${BPN}.git"
+SRC_URI = "git://github.com/OpenSC/${BPN}.git;protocol=https"
 SRC_URI[md5sum] = "9f62af9f475901b89355266141306673"
 SRC_URI[sha256sum] = "494ec59c93e7c56c528f335d9353849e2e7c94a6b1b41c89604694e738113386"
 

--- a/meta-oe/recipes-dbs/leveldb/leveldb_git.bb
+++ b/meta-oe/recipes-dbs/leveldb/leveldb_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=92d1b128950b11ba8495b64938fc164d"
 SRCREV = "a53934a3ae1244679f812d998a4f16f2c7f309a6"
 PV = "1.20+git${SRCPV}"
 
-SRC_URI = "git://github.com/google/${BPN}.git \
+SRC_URI = "git://github.com/google/${BPN}.git;protocol=https \
            file://0001-build_detect_platform-Check-for-__SSE4_2__.patch \
            file://0002-makefile-build-SHARED_MEMENVLIB.patch \
            file://0001-Makefile-Fix-parallel-build.patch \

--- a/meta-oe/recipes-dbs/mongodb/mongodb_git.bb
+++ b/meta-oe/recipes-dbs/mongodb/mongodb_git.bb
@@ -9,7 +9,7 @@ inherit scons dos2unix siteinfo
 
 PV = "3.4.13+git${SRCPV}"
 SRCREV = "fbdef2ccc53e0fcc9afb570063633d992b2aae42"
-SRC_URI = "git://github.com/mongodb/mongo.git;branch=v3.4 \
+SRC_URI = "git://github.com/mongodb/mongo.git;branch=v3.4;protocol=https \
            file://0001-Tell-scons-to-use-build-settings-from-environment-va.patch \
            file://0002-d_state.cpp-Add-missing-dependenncy-on-local_shardin.patch \
            file://0001-Use-long-long-instead-of-int64_t.patch \

--- a/meta-oe/recipes-dbs/rocksdb/rocksdb_git.bb
+++ b/meta-oe/recipes-dbs/rocksdb/rocksdb_git.bb
@@ -10,7 +10,7 @@ SRCREV = "8969445642039566214d650cc6614849e7dd5e17"
 SRCBRANCH = "5.12.fb"
 PV = "5.12.2"
 
-SRC_URI = "git://github.com/facebook/${BPN}.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/facebook/${BPN}.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/breakpad/breakpad_git.bb
+++ b/meta-oe/recipes-devtools/breakpad/breakpad_git.bb
@@ -25,9 +25,9 @@ SRCREV_protobuf = "cb6dd4ef5f82e41e06179dcd57d3b1d9246ad6ac"
 SRCREV_lss = "a91633d172407f6c83dd69af11510b37afebb7f9"
 SRCREV_gyp = "324dd166b7c0b39d513026fa52d6280ac6d56770"
 
-SRC_URI = "git://github.com/google/breakpad;name=breakpad \
-           git://github.com/google/googletest.git;destsuffix=git/src/testing/gtest;name=gtest \
-           git://github.com/google/protobuf.git;destsuffix=git/src/third_party/protobuf/protobuf;name=protobuf \
+SRC_URI = "git://github.com/google/breakpad;name=breakpad;protocol=https \
+           git://github.com/google/googletest.git;destsuffix=git/src/testing/gtest;name=gtest;protocol=https \
+           git://github.com/google/protobuf.git;destsuffix=git/src/third_party/protobuf/protobuf;name=protobuf;protocol=https \
            git://chromium.googlesource.com/linux-syscall-support;protocol=https;destsuffix=git/src/third_party/lss;name=lss \
            git://chromium.googlesource.com/external/gyp;protocol=https;destsuffix=git/src/tools/gyp;name=gyp \
            file://0001-Replace-use-of-struct-ucontext-with-ucontext_t.patch \

--- a/meta-oe/recipes-devtools/capnproto/capnproto_0.6.1.bb
+++ b/meta-oe/recipes-devtools/capnproto/capnproto_0.6.1.bb
@@ -7,7 +7,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=0a5b5b742baf10cc1c158579eba7fb1d"
 
 SRCREV = "c949a18da5f041a36cc218c5c4b79c7705999b4f"
-SRC_URI = "git://github.com/sandstorm-io/capnproto.git;branch=release-${PV}"
+SRC_URI = "git://github.com/sandstorm-io/capnproto.git;branch=release-${PV};protocol=https"
 
 EXTRA_OECMAKE += "\
     -DBUILD_TESTING=OFF \

--- a/meta-oe/recipes-devtools/concurrencykit/concurrencykit_git.bb
+++ b/meta-oe/recipes-devtools/concurrencykit/concurrencykit_git.bb
@@ -10,7 +10,7 @@ SECTION = "base"
 PV = "0.5.1+git${SRCPV}"
 SRCREV = "f97d3da5c375ac2fc5a9173cdd36cb828915a2e1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a0b24c1a8f9ad516a297d055b0294231"
-SRC_URI = "git://github.com/concurrencykit/ck.git \
+SRC_URI = "git://github.com/concurrencykit/ck.git;protocol=https \
            file://cross.patch \
 "
 

--- a/meta-oe/recipes-devtools/flatbuffers/flatbuffers_1.9.0.bb
+++ b/meta-oe/recipes-devtools/flatbuffers/flatbuffers_1.9.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a873c5645c184d51e0f9b34e1d7cf559"
 
 SRCREV = "25a15950f5a24d7217689739ed8f6dac64912d62"
 
-SRC_URI = "git://github.com/google/flatbuffers.git \
+SRC_URI = "git://github.com/google/flatbuffers.git;protocol=https \
            file://0001-correct-version-for-so-lib.patch \
            file://0001-flatbuffers-Move-EndianSwap-template-to-flatbuffers-.patch \
            file://0002-use-__builtin_bswap16-when-building-with-clang.patch \

--- a/meta-oe/recipes-devtools/jsoncpp/jsoncpp_1.8.4.bb
+++ b/meta-oe/recipes-devtools/jsoncpp/jsoncpp_1.8.4.bb
@@ -12,7 +12,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fa2a23dd1dc6c139f35105379d76df2b"
 
 SRCREV = "ddabf50f72cf369bf652a95c4d9fe31a1865a781"
-SRC_URI = "git://github.com/open-source-parsers/jsoncpp"
+SRC_URI = "git://github.com/open-source-parsers/jsoncpp;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/jsonrpc/jsonrpc_0.7.0.bb
+++ b/meta-oe/recipes-devtools/jsonrpc/jsonrpc_0.7.0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ee72d601854d5d2a065cf642883c489b"
 
 PV = "0.7.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/cinemast/libjson-rpc-cpp \
+SRC_URI = "git://github.com/cinemast/libjson-rpc-cpp;protocol=https \
            file://0001-cmake-replace-hardcoded-lib-CMAKE_LIBRARY_PATH-with-.patch \
            file://0001-filedescriptorclient-Typecast-min-arguments-correctl.patch \
            file://0001-filedescriptorserver-Include-sys-select.h-before-oth.patch \

--- a/meta-oe/recipes-devtools/msgpack/msgpack-c_2.1.5.bb
+++ b/meta-oe/recipes-devtools/msgpack/msgpack-c_2.1.5.bb
@@ -11,7 +11,7 @@ PV .= "+git${SRCPV}"
 
 SRCREV = "208595b2620cf6260ce3d6d4cf8543f13b206449"
 
-SRC_URI = "git://github.com/msgpack/msgpack-c \
+SRC_URI = "git://github.com/msgpack/msgpack-c;protocol=https \
            file://0001-Fix-Werror-class-memaccess.patch \
            "
 

--- a/meta-oe/recipes-devtools/perl/ipc-run_0.96.bb
+++ b/meta-oe/recipes-devtools/perl/ipc-run_0.96.bb
@@ -9,7 +9,7 @@ LICENSE = "Artistic-1.0 | GPL-1.0+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0ebd37caf53781e8b7223e6b99b63f4e"
 DEPENDS = "perl"
 
-SRC_URI = "git://github.com/toddr/IPC-Run.git"
+SRC_URI = "git://github.com/toddr/IPC-Run.git;protocol=https"
 SRCREV = "96066366ac8c401dff9c979d04f25dc8219ffcc1"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-devtools/pmtools/pmtools_git.bb
+++ b/meta-oe/recipes-devtools/pmtools/pmtools_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
 PV = "20130209+git${SRCPV}"
 
-SRC_URI = "git://github.com/anyc/pmtools.git \
+SRC_URI = "git://github.com/anyc/pmtools.git;protocol=https \
     file://pmtools-switch-to-dynamic-buffer-for-huge-ACPI-table.patch \
 "
 SRCREV = "3ebe0e54c54061b4c627236cbe35d820de2e1168"

--- a/meta-oe/recipes-devtools/protobuf/protobuf-c_1.3.0.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf-c_1.3.0.bb
@@ -20,7 +20,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=cb901168715f4782a2b06c3ddaefa558"
 PV .= "+git${SRCPV}"
 SRCREV = "dac1a65feac4ad72f612aab99f487056fbcf5c1a"
 
-SRC_URI = "git://github.com/protobuf-c/protobuf-c.git"
+SRC_URI = "git://github.com/protobuf-c/protobuf-c.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-devtools/protobuf/protobuf_3.5.1.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf_3.5.1.bb
@@ -20,7 +20,7 @@ SRCREV = "106ffc04be1abf3ff3399f54ccf149815b287dd9"
 
 PV = "3.5.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/google/protobuf.git;branch=3.5.x \
+SRC_URI = "git://github.com/google/protobuf.git;branch=3.5.x;protocol=https \
 	   file://run-ptest \
           "
 

--- a/meta-oe/recipes-devtools/rapidjson/rapidjson_git.bb
+++ b/meta-oe/recipes-devtools/rapidjson/rapidjson_git.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://license.txt;md5=ba04aa8f65de1396a7e59d1d746c2125"
 
-SRC_URI = "git://github.com/miloyip/rapidjson.git;nobranch=1 \
+SRC_URI = "git://github.com/miloyip/rapidjson.git;nobranch=1;protocol=https \
            file://remove-march-native-from-CMAKE_CXX_FLAGS.patch \
 "
 

--- a/meta-oe/recipes-devtools/uftrace/uftrace_0.8.bb
+++ b/meta-oe/recipes-devtools/uftrace/uftrace_0.8.bb
@@ -11,7 +11,7 @@ DEPENDS_append_libc-musl = " argp-standalone"
 inherit autotools
 
 SRCREV = "5af9ff9fa89c340617e52c8ed05798b352a7145c"
-SRC_URI = "git://github.com/namhyung/${BPN}"
+SRC_URI = "git://github.com/namhyung/${BPN};protocol=https"
 S = "${WORKDIR}/git"
 
 LDFLAGS_append_libc-musl = " -largp"

--- a/meta-oe/recipes-devtools/xmlrpc-c/xmlrpc-c_1.31.0.bb
+++ b/meta-oe/recipes-devtools/xmlrpc-c/xmlrpc-c_1.31.0.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://xmlrpc-c.sourceforge.net/"
 LICENSE = "BSD & MIT"
 LIC_FILES_CHKSUM = "file://doc/COPYING;md5=aefbf81ba0750f02176b6f86752ea951"
 
-SRC_URI = "git://github.com/ensc/xmlrpc-c.git;branch=master \
+SRC_URI = "git://github.com/ensc/xmlrpc-c.git;branch=master;protocol=https \
            file://0001-fix-compile-failure-against-musl-C-library.patch \
            file://0002-fix-formatting-issues.patch \
 "

--- a/meta-oe/recipes-devtools/yajl/yajl_1.0.12.bb
+++ b/meta-oe/recipes-devtools/yajl/yajl_1.0.12.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=da2e9aa80962d54e7c726f232a2bd1e8"
 
 # Use 1.0.12 tag
 SRCREV = "17b1790fb9c8abbb3c0f7e083864a6a014191d56"
-SRC_URI = "git://github.com/lloyd/yajl;nobranch=1"
+SRC_URI = "git://github.com/lloyd/yajl;nobranch=1;protocol=https"
 
 inherit cmake lib_package
 

--- a/meta-oe/recipes-devtools/yajl/yajl_2.1.0.bb
+++ b/meta-oe/recipes-devtools/yajl/yajl_2.1.0.bb
@@ -8,7 +8,7 @@ HOMEPAGE = "http://lloyd.github.com/yajl/"
 LICENSE = "ISC"
 LIC_FILES_CHKSUM = "file://COPYING;md5=39af6eb42999852bdd3ea00ad120a36d"
 
-SRC_URI = "git://github.com/lloyd/yajl"
+SRC_URI = "git://github.com/lloyd/yajl;protocol=https"
 SRCREV = "a0ecdde0c042b9256170f2f8890dd9451a4240aa"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/cmpi-bindings/cmpi-bindings_git.bb
+++ b/meta-oe/recipes-extended/cmpi-bindings/cmpi-bindings_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b19ee058d2d5f69af45da98051d91064"
 SECTION = "Development/Libraries"
 DEPENDS = "swig-native python3 sblim-cmpi-devel"
 
-SRC_URI = "git://github.com/kkaempf/cmpi-bindings.git;protocol=http \
+SRC_URI = "git://github.com/kkaempf/cmpi-bindings.git;protocol=http;protocol=https \
            file://cmpi-bindings-0.4.17-no-ruby-perl.patch \
            file://cmpi-bindings-0.4.17-sblim-sigsegv.patch \
            file://cmpi-bindings-0.9.5-python-lib-dir.patch \

--- a/meta-oe/recipes-extended/hexedit/hexedit_1.4.2.bb
+++ b/meta-oe/recipes-extended/hexedit/hexedit_1.4.2.bb
@@ -6,7 +6,7 @@ DEPENDS = "ncurses"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-SRC_URI = "git://github.com/pixel/hexedit.git \
+SRC_URI = "git://github.com/pixel/hexedit.git;protocol=https \
     "
 
 SRCREV = "800e4b2e6280531a84fd23ee0b48e16baeb90878"

--- a/meta-oe/recipes-extended/hiredis/hiredis_0.13.1.bb
+++ b/meta-oe/recipes-extended/hiredis/hiredis_0.13.1.bb
@@ -5,7 +5,7 @@ SECTION = "libs"
 DEPENDS = "redis"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d84d659a35c666d23233e54503aaea51"
-SRC_URI = "git://github.com/redis/hiredis;protocol=git;rev=f58dd249d6ed47a7e835463c3b04722972281dbb \
+SRC_URI = "git://github.com/redis/hiredis;protocol=https;rev=f58dd249d6ed47a7e835463c3b04722972281dbb \
            file://0001-Makefile-remove-hardcoding-of-CC.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/isomd5sum/isomd5sum_1.2.1.bb
+++ b/meta-oe/recipes-extended/isomd5sum/isomd5sum_1.2.1.bb
@@ -7,7 +7,7 @@ RDEPENDS_${PN} = "openssl curl"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8ca43cbc842c2336e835926c2166c28b"
 
-SRC_URI = "git://github.com/rhinstaller/isomd5sum.git;branch=master \
+SRC_URI = "git://github.com/rhinstaller/isomd5sum.git;branch=master;protocol=https \
            file://0001-tweak-install-prefix.patch \
            file://0002-fix-parallel-error.patch \
 "

--- a/meta-oe/recipes-extended/konkretcmpi/konkretcmpi_0.9.2.bb
+++ b/meta-oe/recipes-extended/konkretcmpi/konkretcmpi_0.9.2.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=f673270bfc350d9ce1efc8724c6c1873"
 DEPENDS_append_class-target = " swig-native sblim-cmpi-devel python"
 DEPENDS_append_class-native = " cmpi-bindings-native"
 
-SRC_URI = "git://github.com/rnovacek/konkretcmpi.git \
+SRC_URI = "git://github.com/rnovacek/konkretcmpi.git;protocol=https \
            file://0001-CMakeLists.txt-fix-lib64-can-not-be-shiped-in-64bit-.patch \
            file://0001-drop-including-rpath-cmake-module.patch \
            "

--- a/meta-oe/recipes-extended/lcdproc/lcdproc_git.bb
+++ b/meta-oe/recipes-extended/lcdproc/lcdproc_git.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=18810669f13b87348459e611d31ab760 \
 BASEPV = "0.5.8"
 PV = "${BASEPV}+git${SRCPV}"
 SRCREV = "f5156e2e41bb418f14761afea22eee8efb49fb85"
-SRC_URI = "git://github.com/lcdproc/lcdproc;branch=lcdproc-${BASEPV} \
+SRC_URI = "git://github.com/lcdproc/lcdproc;branch=lcdproc-${BASEPV};protocol=https \
            file://0001-include-asm-ioctl.h-explicitly.patch \
            "
 

--- a/meta-oe/recipes-extended/libblockdev/libblockdev_2.18.bb
+++ b/meta-oe/recipes-extended/libblockdev/libblockdev_2.18.bb
@@ -18,7 +18,7 @@ DEPENDS += " \
 
 SRCREV = "0debeb45562ac3d8f6f43f6f942b238abab55be9"
 SRC_URI = " \
-    git://github.com/rhinstaller/libblockdev;branch=master \
+    git://github.com/rhinstaller/libblockdev;branch=master;protocol=https \
     file://0001-fix-configure-and-compile-failures.patch \
 "
 

--- a/meta-oe/recipes-extended/libcec/libcec_git.bb
+++ b/meta-oe/recipes-extended/libcec/libcec_git.bb
@@ -12,7 +12,7 @@ DEPENDS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ''
 PV = "4.0.1+gitr${SRCPV}"
 
 SRCREV = "2fc92b5f02dca702da92ccc5ed7b805b240ef5df"
-SRC_URI = "git://github.com/Pulse-Eight/libcec.git \
+SRC_URI = "git://github.com/Pulse-Eight/libcec.git;protocol=https \
            file://python-install-location.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/libqb/libqb_1.0.3.bb
+++ b/meta-oe/recipes-extended/libqb/libqb_1.0.3.bb
@@ -13,7 +13,7 @@ PV .= "+git${SRCPV}"
 
 # v1.0.3
 SRCREV = "28dff090c74b6ba8609c4797294a5afe3fe73987"
-SRC_URI = "git://github.com/ClusterLabs/${BPN}.git \
+SRC_URI = "git://github.com/ClusterLabs/${BPN}.git;protocol=https \
            file://0001-build-fix-configure-script-neglecting-re-enable-out-.patch \
           "
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/md5deep/md5deep_4.4.bb
+++ b/meta-oe/recipes-extended/md5deep/md5deep_4.4.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9190f660105b9a56cdb272309bfd5491"
 # Release 4.4
 SRCREV = "cd2ed7416685a5e83eb10bb659d6e9bec01244ae"
 
-SRC_URI = "git://github.com/jessek/hashdeep.git \
+SRC_URI = "git://github.com/jessek/hashdeep.git;protocol=https \
         file://wrong-variable-expansion.patch \
         file://0001-Fix-errors-found-by-clang.patch \
         "

--- a/meta-oe/recipes-extended/mml-widget/gtkmathview_0.8.0.bb
+++ b/meta-oe/recipes-extended/mml-widget/gtkmathview_0.8.0.bb
@@ -8,7 +8,7 @@ PR = "r3"
 SRCREV = "0bc2cfa0a47aed2c8a63abd989cb8da4dcceb2ec"
 PV = "0.8.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/GNOME/gtkmathview.git \
+SRC_URI = "git://github.com/GNOME/gtkmathview.git;protocol=https \
     file://use_hostcxx.patch \
     file://0001-include-cstdio-to-get-printf-definitions.patch \
     file://0002-configure.ac-header-detection-of-hash_map-is-broken-.patch \

--- a/meta-oe/recipes-extended/mraa/mraa_git.bb
+++ b/meta-oe/recipes-extended/mraa/mraa_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4b92a3b497d7943042a6db40c088c3f2"
 SRCREV = "fbb7d9232067eac3f4508a37a8f7ea0c4fcebacb"
 PV = "1.9.0-git${SRCPV}"
 
-SRC_URI = "git://github.com/intel-iot-devkit/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/intel-iot-devkit/${BPN}.git;protocol=http;protocol=https \
            "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/openwsman/openwsman_2.6.3.bb
+++ b/meta-oe/recipes-extended/openwsman/openwsman_2.6.3.bb
@@ -18,7 +18,7 @@ REQUIRED_DISTRO_FEATURES = "pam"
 SRCREV = "feb7ec9b004fcaea0dbe65ce8a1a79cc29dd994c"
 PV = "2.6.3"
 
-SRC_URI = "git://github.com/Openwsman/openwsman.git \
+SRC_URI = "git://github.com/Openwsman/openwsman.git;protocol=https \
            file://libssl-is-required-if-eventint-supported.patch \
            file://openwsmand.service \
            file://0001-lock.c-Define-PTHREAD_MUTEX_RECURSIVE_NP-if-undefine.patch \

--- a/meta-oe/recipes-extended/p8platform/p8platform_git.bb
+++ b/meta-oe/recipes-extended/p8platform/p8platform_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/os.h;md5=752555fa94e82005d45fd201fee5bd33"
 
 PV = "2.1.0"
 
-SRC_URI = "git://github.com/Pulse-Eight/platform.git"
+SRC_URI = "git://github.com/Pulse-Eight/platform.git;protocol=https"
 SRCREV = "d7bceb64541cb046421cbcd4c98d91e9bf24822f"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/rrdtool/rrdtool_1.6.0.bb
+++ b/meta-oe/recipes-extended/rrdtool/rrdtool_1.6.0.bb
@@ -10,7 +10,7 @@ SRCREV = "61f116744262c4c18922dcf806e496715f199669"
 PV = "1.6.0"
 
 SRC_URI = "\
-    git://github.com/oetiker/rrdtool-1.x.git;branch=1.6;protocol=http; \
+    git://github.com/oetiker/rrdtool-1.x.git;branch=1.6;protocol=http;;protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/socketcan/can-utils_git.bb
+++ b/meta-oe/recipes-extended/socketcan/can-utils_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://include/linux/can.h;endline=43;md5=390a2c9a3c5e3595a0
 
 DEPENDS = "libsocketcan"
 
-SRC_URI = "git://github.com/linux-can/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/linux-can/${BPN}.git;protocol=https;branch=master"
 SRCREV = "4c8fb05cb4d6ddcd67299008db54af423f86fd05"
 
 PV = "0.0+gitr${SRCPV}"

--- a/meta-oe/recipes-extended/sysdig/sysdig_git.bb
+++ b/meta-oe/recipes-extended/sysdig/sysdig_git.bb
@@ -13,7 +13,7 @@ OECMAKE_GENERATOR = "Unix Makefiles"
 DEPENDS = "luajit zlib ncurses"
 RDEPENDS_${PN} = "bash"
 
-SRC_URI = "git://github.com/draios/sysdig.git;branch=master \
+SRC_URI = "git://github.com/draios/sysdig.git;branch=master;protocol=https \
            file://0001-libsinsp-Port-to-build-with-lua-5.2.patch \
            file://0001-Fix-build-with-musl-backtrace-APIs-are-glibc-specifi.patch \
           "

--- a/meta-oe/recipes-extended/upm/upm_git.bb
+++ b/meta-oe/recipes-extended/upm/upm_git.bb
@@ -11,7 +11,7 @@ SRCREV = "cc7fec9ae0228add9011bf1c2cd5e0ca2ba0d4f0"
 PV = "1.6.0-git${SRCPV}"
 
 SRC_URI = " \
-    git://github.com/intel-iot-devkit/${BPN}.git;protocol=http \
+    git://github.com/intel-iot-devkit/${BPN}.git;protocol=http;protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-extended/wipe/wipe_git.bb
+++ b/meta-oe/recipes-extended/wipe/wipe_git.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "http://lambda-diode.com/software/wipe/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://GPL;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-SRC_URI = "git://github.com/berke/wipe.git;branch=master \
+SRC_URI = "git://github.com/berke/wipe.git;branch=master;protocol=https \
     file://support-cross-compile-for-linux.patch \
     file://makefile-add-ldflags.patch \
 "

--- a/meta-oe/recipes-extended/zlog/zlog_git.bb
+++ b/meta-oe/recipes-extended/zlog/zlog_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 PV = "1.2.12+git${SRCPV}"
 
 SRCREV = "13904dab2878aa2654d0c20fb8600a3dc5f2dd68"
-SRC_URI = "git://github.com/HardySimpson/zlog \
+SRC_URI = "git://github.com/HardySimpson/zlog;protocol=https \
            file://0001-event.c-Cast-pthread_t-to-unsigned-long-instead-of-u.patch \
            "
 

--- a/meta-oe/recipes-graphics/dietsplash/dietsplash_git.bb
+++ b/meta-oe/recipes-graphics/dietsplash/dietsplash_git.bb
@@ -8,7 +8,7 @@ PV = "0.3"
 PR = "r1"
 
 SRCREV = "ef2e1a390e768e21e6a6268977580ee129a96633"
-SRC_URI = "git://github.com/lucasdemarchi/dietsplash.git \
+SRC_URI = "git://github.com/lucasdemarchi/dietsplash.git;protocol=https \
            file://0001-configure.ac-Do-not-demand-linker-hash-style.patch \
            "
 

--- a/meta-oe/recipes-graphics/dnfdragora/dnfdragora_git.bb
+++ b/meta-oe/recipes-graphics/dnfdragora/dnfdragora_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504 \
                    "
 
-SRC_URI = "git://github.com/manatools/dnfdragora.git \
+SRC_URI = "git://github.com/manatools/dnfdragora.git;protocol=https \
            file://0001-disable-build-manpages.patch \
            file://0001-Do-not-set-PYTHON_INSTALL_DIR-by-running-python.patch \
            file://0001-To-fix-error-when-do_package.patch \

--- a/meta-oe/recipes-graphics/fontforge/fontforge_20170731.bb
+++ b/meta-oe/recipes-graphics/fontforge/fontforge_20170731.bb
@@ -13,7 +13,7 @@ inherit autotools pkgconfig pythonnative distro_features_check gettext
 
 REQUIRED_DISTRO_FEATURES_append_class-target = " x11"
 
-SRC_URI = "git://github.com/${BPN}/${BPN}.git"
+SRC_URI = "git://github.com/${BPN}/${BPN}.git;protocol=https"
 # tag 20170731
 SRCREV = "b9149c13e8f9464fc21473f1f676b36a2130775d"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-graphics/glm/glm_0.9.9-a2.bb
+++ b/meta-oe/recipes-graphics/glm/glm_0.9.9-a2.bb
@@ -11,7 +11,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://readme.md;beginline=21;endline=22;md5=3075b5727d36f29edccf97b93e72b790"
 
 SRC_URI = " \
-    git://github.com/g-truc/glm;branch=master \
+    git://github.com/g-truc/glm;branch=master;protocol=https \
     file://0001-Make-GLM_ENABLE_EXPERIMENTAL-a-configurable-option.patch \
     file://0002-glm-install-headers-only.patch \
 "

--- a/meta-oe/recipes-graphics/libyui/libyui-ncurses_git.bb
+++ b/meta-oe/recipes-graphics/libyui/libyui-ncurses_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.lgpl-3;md5=e6a600fd5e1d9cbde2d983680233ad02 \
     file://COPYING.lgpl-2.1;md5=4fbd65380cdd255951079008b364516c \
 "
 
-SRC_URI = "git://github.com/libyui/libyui-ncurses.git \
+SRC_URI = "git://github.com/libyui/libyui-ncurses.git;protocol=https \
            file://0001-use-_nl_msg_cat_cntr-only-with-glibc.patch \
           "
 

--- a/meta-oe/recipes-graphics/libyui/libyui_git.bb
+++ b/meta-oe/recipes-graphics/libyui/libyui_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING.gpl-3;md5=d32239bcb673463ab874e80d47fae504 \
                     file://COPYING.lgpl-3;md5=e6a600fd5e1d9cbde2d983680233ad02 \
                    "
 
-SRC_URI = "git://github.com/libyui/libyui.git \
+SRC_URI = "git://github.com/libyui/libyui.git;protocol=https \
            file://0001-Fix-GCC-8-warning.patch \
            file://0001-Fix-build-with-clang.patch \
            "

--- a/meta-oe/recipes-graphics/qrencode/qrencode_git.bb
+++ b/meta-oe/recipes-graphics/qrencode/qrencode_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 PV = "4.0.0+git${SRCPV}"
 
 SRCREV = "07f3c5d4bf9136711422cc7dbf28aff469da220a"
-SRC_URI = "git://github.com/fukuchi/libqrencode.git"
+SRC_URI = "git://github.com/fukuchi/libqrencode.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-graphics/tesseract/tesseract-lang_git.bb
+++ b/meta-oe/recipes-graphics/tesseract/tesseract-lang_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9648bd7af63bd3cc4f5ac046d12c49e4"
 
 PV = "3.04.00+git${SRCPV}"
 SRCREV = "3cf1e2df1fe1d1da29295c9ef0983796c7958b7d"
-SRC_URI = "git://github.com/tesseract-ocr/tessdata.git"
+SRC_URI = "git://github.com/tesseract-ocr/tessdata.git;protocol=https"
 S = "${WORKDIR}/git"
 
 inherit allarch

--- a/meta-oe/recipes-graphics/tesseract/tesseract_git.bb
+++ b/meta-oe/recipes-graphics/tesseract/tesseract_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=7ea4f9a43aba9d3c849fe5c203a0ed40"
 BRANCH = "3.05"
 PV = "${BRANCH}.01+git${SRCPV}"
 SRCREV = "215866151e774972c9502282111b998d7a053562"
-SRC_URI = "git://github.com/${BPN}-ocr/${BPN}.git;branch=${BRANCH}"
+SRC_URI = "git://github.com/${BPN}-ocr/${BPN}.git;branch=${BRANCH};protocol=https"
 S = "${WORKDIR}/git"
 
 DEPENDS = "leptonica"

--- a/meta-oe/recipes-graphics/tigervnc/tigervnc_1.8.0.bb
+++ b/meta-oe/recipes-graphics/tigervnc/tigervnc_1.8.0.bb
@@ -17,7 +17,7 @@ B = "${S}"
 
 SRCREV = "4d6e1b8306a8cca8ad5e15ff8201f6ea24459cfd"
 
-SRC_URI = "git://github.com/TigerVNC/tigervnc.git;branch=1.8-branch \
+SRC_URI = "git://github.com/TigerVNC/tigervnc.git;branch=1.8-branch;protocol=https \
            file://0001-tigervnc-remove-includedir.patch \
            file://0002-do-not-build-tests-sub-directory.patch \
            file://0003-add-missing-dynamic-library-to-FLTK_LIBRARIES.patch \

--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-droid_git.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-droid_git.bb
@@ -8,7 +8,7 @@ SRCREV = "21e6e2de1f0062f949fcc52d0b4559dfa3246e0e"
 PV = "0.1+gitr${SRCPV}"
 PR = "r3"
 
-SRC_URI = "git://github.com/android/platform_frameworks_base.git;branch=master"
+SRC_URI = "git://github.com/android/platform_frameworks_base.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git/data/fonts"
 

--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-lohit_2.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-lohit_2.bb
@@ -8,7 +8,7 @@ LICENSE = "OFL-1.1"
 LIC_FILES_CHKSUM = "file://OFL.txt;md5=7dfa0a236dc535ad2d2548e6170c4402"
 
 SRCREV = "d678f1b1807ea5602586279e90b5db6d62ed475e"
-SRC_URI = "git://github.com/pravins/lohit.git;branch=master"
+SRC_URI = "git://github.com/pravins/lohit.git;branch=master;protocol=https"
 
 DEPENDS = "fontforge-native"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-multimedia/jack/jack_git.bb
+++ b/meta-oe/recipes-multimedia/jack/jack_git.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS = "libsamplerate0 libsndfile1 readline"
 
-SRC_URI = "git://github.com/jackaudio/jack2.git"
+SRC_URI = "git://github.com/jackaudio/jack2.git;protocol=https"
 SRCREV = "c1647819eed6d11f94b21981d9c869629299f357"
 PV = "1.9.12"
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-multimedia/libass/libass_0.14.0.bb
+++ b/meta-oe/recipes-multimedia/libass/libass_0.14.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a42532a0684420bdb15556c3cdd49a75"
 
 DEPENDS = "enca fontconfig freetype libpng fribidi"
 
-SRC_URI = "git://github.com/libass/libass.git"
+SRC_URI = "git://github.com/libass/libass.git;protocol=https"
 SRCREV = "73284b676b12b47e17af2ef1b430527299e10c17"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/avro/avro-c_1.8.1.bb
+++ b/meta-oe/recipes-support/avro/avro-c_1.8.1.bb
@@ -9,7 +9,7 @@ DEPENDS = "jansson zlib xz"
 PV .= "+git${SRCPV}"
 
 SRCREV = "4b3677c32b879e0e7f717eb95f9135ac654da760"
-SRC_URI = "git://github.com/apache/avro \
+SRC_URI = "git://github.com/apache/avro;protocol=https \
            file://0001-avro-c-Fix-build-with-clang-compiler.patch;patchdir=../../ \
 "
 

--- a/meta-oe/recipes-support/bdwgc/bdwgc_7.6.0.bb
+++ b/meta-oe/recipes-support/bdwgc/bdwgc_7.6.0.bb
@@ -22,7 +22,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://README.QUICK;md5=4f81f24ec69726c312487c2ac740e9e3"
 
 SRCREV = "8ac1d84a40eb7a431fec1b8097e3f24b48fb23fa"
-SRC_URI = "git://github.com/ivmai/bdwgc.git \
+SRC_URI = "git://github.com/ivmai/bdwgc.git;protocol=https \
            file://0001-configure.ac-add-check-for-NO_GETCONTEXT-definition.patch \
            file://musl_header_fix.patch \
           "

--- a/meta-oe/recipes-support/ceres-solver/ceres-solver_1.14.bb
+++ b/meta-oe/recipes-support/ceres-solver/ceres-solver_1.14.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://ceres-solver.org/"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=35e00f0c4c96a0820a03e0b31e6416be"
 
-SRC_URI = "git://github.com/ceres-solver/ceres-solver.git"
+SRC_URI = "git://github.com/ceres-solver/ceres-solver.git;protocol=https"
 SRCREV = "facb199f3eda902360f9e1d5271372b7e54febe1"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/daemonize/daemonize_git.bb
+++ b/meta-oe/recipes-support/daemonize/daemonize_git.bb
@@ -7,7 +7,7 @@ PV = "1.7.7+git${SRCPV}"
 inherit autotools
 
 SRCREV = "6b10308b13c13e7b911e75e27bf7e65c30d58799"
-SRC_URI = "git://github.com/bmc/daemonize.git \
+SRC_URI = "git://github.com/bmc/daemonize.git;protocol=https \
            file://fix-ldflags-for-gnuhash.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/digitemp/digitemp_git.bb
+++ b/meta-oe/recipes-support/digitemp/digitemp_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=44fee82a1d2ed0676cf35478283e0aa0"
 
 PV = "3.7.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/bcl/digitemp"
+SRC_URI = "git://github.com/bcl/digitemp;protocol=https"
 
 SRCREV = "389f67655efa1674f595106c3a47b5ad082609a7"
 

--- a/meta-oe/recipes-support/dstat/dstat_0.7.3.bb
+++ b/meta-oe/recipes-support/dstat/dstat_0.7.3.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS += "asciidoc-native xmlto-native"
 
-SRC_URI = "git://github.com/dagwieers/dstat.git"
+SRC_URI = "git://github.com/dagwieers/dstat.git;protocol=https"
 
 SRCREV = "ebace6d4177f8748f35cec87f7a49946046b0a20"
 

--- a/meta-oe/recipes-support/epeg/epeg_git.bb
+++ b/meta-oe/recipes-support/epeg/epeg_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e7732a9290ea1e4b034fdc15cf49968d \
                     file://COPYING-PLAIN;md5=f59cacc08235a546b0c34a5422133035"
 DEPENDS = "jpeg libexif"
 
-SRC_URI = "git://github.com/mattes/epeg.git"
+SRC_URI = "git://github.com/mattes/epeg.git;protocol=https"
 SRCREV = "337f55346425fbf2d283e794b702318ef2a74bcb"
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/freerdp/freerdp_git.bb
+++ b/meta-oe/recipes-support/freerdp/freerdp_git.bb
@@ -14,7 +14,7 @@ PV = "2.0.0+gitr${SRCPV}"
 PKGV = "${GITPKGVTAG}"
 
 SRCREV = "1648deb435ad52206f7aa2afe4b4dff71d9329bc"
-SRC_URI = "git://github.com/FreeRDP/FreeRDP.git \
+SRC_URI = "git://github.com/FreeRDP/FreeRDP.git;protocol=https \
     file://winpr-makecert-Build-with-install-RPATH.patch \
     file://0001-Fix-gstreamer-1.0-detection.patch \
 "

--- a/meta-oe/recipes-support/gd/gd_2.2.5.bb
+++ b/meta-oe/recipes-support/gd/gd_2.2.5.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=07384b3aa2e0d39afca0d6c40286f545"
 
 DEPENDS = "freetype libpng jpeg zlib tiff"
 
-SRC_URI = "git://github.com/libgd/libgd.git;branch=GD-2.2 \
+SRC_URI = "git://github.com/libgd/libgd.git;branch=GD-2.2;protocol=https \
           "
 
 SRCREV = "8255231b68889597d04d451a72438ab92a405aba"

--- a/meta-oe/recipes-support/gflags/gflags_2.2.0.bb
+++ b/meta-oe/recipes-support/gflags/gflags_2.2.0.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/gflags/gflags"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING.txt;md5=c80d1a3b623f72bb85a4c75b556551df"
 
-SRC_URI = "git://github.com/gflags/gflags.git"
+SRC_URI = "git://github.com/gflags/gflags.git;protocol=https"
 SRCREV = "f8a0efe03aa69b3336d8e228b37d4ccb17324b88"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/glog/glog_0.3.4.bb
+++ b/meta-oe/recipes-support/glog/glog_0.3.4.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=dc9db360e0bbd4e46672f3fd91dd6c4b"
 DEPENDS = "libunwind"
 
 SRC_URI = " \
-    git://github.com/google/glog.git \
+    git://github.com/google/glog.git;protocol=https \
     file://0001-configure.ac-Allow-user-to-disable-gflags.patch \
 "
 

--- a/meta-oe/recipes-support/gperftools/gperftools_2.6.1.bb
+++ b/meta-oe/recipes-support/gperftools/gperftools_2.6.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=762732742c73dc6c7fbe8632f06c059a"
 DEPENDS += "libunwind"
 
 SRCREV = "bf840dec0495e17f5c8403e68e10b9d6bf05c559"
-SRC_URI = "git://github.com/gperftools/gperftools \
+SRC_URI = "git://github.com/gperftools/gperftools;protocol=https \
            file://0001-Support-Atomic-ops-on-clang.patch \
            file://0001-Use-ucontext_t-instead-of-struct-ucontext.patch \
            file://0001-fix-build-with-musl-libc.patch \

--- a/meta-oe/recipes-support/gpm/gpm_git.bb
+++ b/meta-oe/recipes-support/gpm/gpm_git.bb
@@ -11,7 +11,7 @@ SRCREV = "1fd19417b8a4dd9945347e98dfa97e4cfd798d77"
 
 DEPENDS = "ncurses"
 
-SRC_URI = "git://github.com/telmich/gpm;protocol=git \
+SRC_URI = "git://github.com/telmich/gpm;protocol=https \
            file://init \
            file://no-docs.patch \
            file://processcreds.patch \

--- a/meta-oe/recipes-support/hidapi/hidapi_git.bb
+++ b/meta-oe/recipes-support/hidapi/hidapi_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "libusb udev"
 PV = "0.7.99+0.8.0-rc1+git${SRCPV}"
 
 SRCREV = "d17db57b9d4354752e0af42f5f33007a42ef2906"
-SRC_URI = "git://github.com/signal11/hidapi.git"
+SRC_URI = "git://github.com/signal11/hidapi.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/hwdata/hwdata_git.bb
+++ b/meta-oe/recipes-support/hwdata/hwdata_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1556547711e8246992b999edd9445a57"
 
 PV = "0.298+git${SRCPV}"
 SRCREV = "9030fbd6ab1538f4d77d3cf1e0b463a7ec25b5c4"
-SRC_URI = "git://github.com/vcrhonek/${BPN}.git"
+SRC_URI = "git://github.com/vcrhonek/${BPN}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/imagemagick/imagemagick_7.0.7.bb
+++ b/meta-oe/recipes-support/imagemagick/imagemagick_7.0.7.bb
@@ -7,7 +7,7 @@ DEPENDS = "lcms bzip2 jpeg libpng librsvg tiff zlib fftw freetype"
 
 BASE_PV := "${PV}"
 PV .= "_7"
-SRC_URI = "git://github.com/ImageMagick/ImageMagick.git "
+SRC_URI = "git://github.com/ImageMagick/ImageMagick.git;protocol=https"
 SRCREV = "e12602b39b5e778240d286b6f9bbbc0fe3fb26c5"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/inih/libinih_git.bb
+++ b/meta-oe/recipes-support/inih/libinih_git.bb
@@ -9,7 +9,7 @@ PR = "r3"
 
 # The github repository provides a cmake and pkg-config integration
 SRCREV = "25078f7156eb8647b3b35dd25f9ae6f8c4ee0589"
-SRC_URI = "git://github.com/OSSystems/inih.git"
+SRC_URI = "git://github.com/OSSystems/inih.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/inotify-tools/inotify-tools_git.bb
+++ b/meta-oe/recipes-support/inotify-tools/inotify-tools_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=ac6c26e52aea428ee7f56dc2c56424c6"
 SRCREV = "1df9af4d6cd0f4af4b1b19254bcf056aed4ae395"
 PV = "3.14+git${SRCPV}"
 
-SRC_URI = "git://github.com/rvoicilas/${BPN} \
+SRC_URI = "git://github.com/rvoicilas/${BPN};protocol=https \
            file://inotifywait-fix-compile-error-with-GCC-6.patch \
            file://inotify-nosys-fix-system-call-number.patch \
           "

--- a/meta-oe/recipes-support/libbytesize/libbytesize_0.10.bb
+++ b/meta-oe/recipes-support/libbytesize/libbytesize_0.10.bb
@@ -11,7 +11,7 @@ B = "${S}"
 
 SRCREV = "369127c0edbba7d1a4e2e02486375dd9d379524f"
 PV = "0.10+git${SRCPV}"
-SRC_URI = "git://github.com/rhinstaller/libbytesize;branch=master \
+SRC_URI = "git://github.com/rhinstaller/libbytesize;branch=master;protocol=https \
            file://0001-remove-python2-support.patch \
 "
 

--- a/meta-oe/recipes-support/libcyusbserial/libcyusbserial_git.bb
+++ b/meta-oe/recipes-support/libcyusbserial/libcyusbserial_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "libusb udev"
 PV = "1.0.0+git${SRCPV}"
 
 SRCREV = "655e2d544183d094f0e2d119c7e0c6206a0ddb3f"
-SRC_URI = "git://github.com/cyrozap/${BPN}.git"
+SRC_URI = "git://github.com/cyrozap/${BPN}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libgit2/libgit2_0.24.3.bb
+++ b/meta-oe/recipes-support/libgit2/libgit2_0.24.3.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=34197a479f637beb9e09e56893f48bc2"
 
 DEPENDS = "curl openssl zlib libssh2"
 
-SRC_URI = "git://github.com/libgit2/libgit2.git;branch=maint/v0.24"
+SRC_URI = "git://github.com/libgit2/libgit2.git;branch=maint/v0.24;protocol=https"
 SRCREV = "4cf1ec7cff28da8838a2f0a9fb330e312ea3f963"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/libp11/libp11_0.4.7.bb
+++ b/meta-oe/recipes-support/libp11/libp11_0.4.7.bb
@@ -8,7 +8,7 @@ LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fad9b3332be894bab9bc501572864b29"
 DEPENDS = "libtool openssl"
 
-SRC_URI = "git://github.com/OpenSC/libp11.git"
+SRC_URI = "git://github.com/OpenSC/libp11.git;protocol=https"
 SRCREV = "64569a391897bd29c5060b19fa4613e619e59277"
 
 S = "${WORKDIR}/git"

--- a/meta-oe/recipes-support/libsoc/libsoc_0.8.2.bb
+++ b/meta-oe/recipes-support/libsoc/libsoc_0.8.2.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENCE;md5=e0bfebea12a718922225ba987b2126a5"
 inherit autotools pkgconfig python-dir
 
 SRCREV = "fd1ad6e7823fa76d8db0d3c5884faffa8ffddafb"
-SRC_URI = "git://github.com/jackmitch/libsoc.git"
+SRC_URI = "git://github.com/jackmitch/libsoc.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/libteam/libteam_1.27.bb
+++ b/meta-oe/recipes-support/libteam/libteam_1.27.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "libnl libdaemon jansson"
 
-SRC_URI = "git://github.com/jpirko/libteam \
+SRC_URI = "git://github.com/jpirko/libteam;protocol=https \
            file://0001-include-sys-select.h-for-fd_set-definition.patch \
            file://0002-teamd-Re-adjust-include-header-order.patch \
            file://0001-team_basic_test.py-disable-RedHat-specific-test.patch \

--- a/meta-oe/recipes-support/libtinyxml2/libtinyxml2_5.0.1.bb
+++ b/meta-oe/recipes-support/libtinyxml2/libtinyxml2_5.0.1.bb
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "Zlib"
 LIC_FILES_CHKSUM = "file://tinyxml2.cpp;endline=22;md5=c19221dbd8a66ad3090462af4c5de5e7"
 
-SRC_URI = "git://github.com/leethomason/tinyxml2.git"
+SRC_URI = "git://github.com/leethomason/tinyxml2.git;protocol=https"
 
 SRCREV = "37bc3aca429f0164adf68c23444540b4a24b5778"
 

--- a/meta-oe/recipes-support/libusbg/libusbg_git.bb
+++ b/meta-oe/recipes-support/libusbg/libusbg_git.bb
@@ -8,7 +8,7 @@ inherit autotools
 
 PV = "0.1.0"
 SRCREV = "a826d136e0e8fa53815f1ba05893e6dd74208c15"
-SRC_URI = "git://github.com/libusbg/libusbg.git \
+SRC_URI = "git://github.com/libusbg/libusbg.git;protocol=https \
            file://0001-Fix-out-of-tree-builds.patch \
           "
 

--- a/meta-oe/recipes-support/ne10/ne10_1.2.1.bb
+++ b/meta-oe/recipes-support/ne10/ne10_1.2.1.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e7fe20c9be97be5579e3ab5d92d3a218"
 SECTION = "libs"
 
-SRC_URI = "git://github.com/projectNe10/Ne10.git \
+SRC_URI = "git://github.com/projectNe10/Ne10.git;protocol=https \
            file://0001-CMakeLists.txt-Remove-mthumb-interwork.patch \
            file://0001-Dont-specify-march-explicitly.patch \
            "

--- a/meta-oe/recipes-support/numactl/numactl_git.bb
+++ b/meta-oe/recipes-support/numactl/numactl_git.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://README;beginline=19;endline=32;md5=5644cc3851cb2499f6
 SRCREV = "ea3a70681c2f523fe58e1d44527f478ca76db74e"
 PV = "2.0.11+git${SRCPV}"
 
-SRC_URI = "git://github.com/numactl/numactl \
+SRC_URI = "git://github.com/numactl/numactl;protocol=https \
     file://fix-null-pointer.patch \
     file://Fix-the-test-output-format.patch \
     file://Makefile \

--- a/meta-oe/recipes-support/opencv/opencv_3.3.bb
+++ b/meta-oe/recipes-support/opencv/opencv_3.3.bb
@@ -38,11 +38,11 @@ IPP_FILENAME = "${@ipp_filename(d)}"
 IPP_MD5 = "${@ipp_md5sum(d)}"
 
 SRCREV_FORMAT = "opencv_contrib_ipp_boostdesc_vgg"
-SRC_URI = "git://github.com/opencv/opencv.git;name=opencv \
-    git://github.com/opencv/opencv_contrib.git;destsuffix=contrib;name=contrib \
-    git://github.com/opencv/opencv_3rdparty.git;branch=ippicv/master_20170418;destsuffix=ipp;name=ipp \
-    git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_boostdesc_20161012;destsuffix=boostdesc;name=boostdesc \
-    git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_vgg_20160317;destsuffix=vgg;name=vgg \
+SRC_URI = "git://github.com/opencv/opencv.git;name=opencv;protocol=https \
+    git://github.com/opencv/opencv_contrib.git;destsuffix=contrib;name=contrib;protocol=https \
+    git://github.com/opencv/opencv_3rdparty.git;branch=ippicv/master_20170418;destsuffix=ipp;name=ipp;protocol=https \
+    git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_boostdesc_20161012;destsuffix=boostdesc;name=boostdesc;protocol=https \
+    git://github.com/opencv/opencv_3rdparty.git;branch=contrib_xfeatures2d_vgg_20160317;destsuffix=vgg;name=vgg;protocol=https \
     https://github.com/tiny-dnn/tiny-dnn/archive/v1.0.0a3.tar.gz;destsuffix=git/3rdparty/tinydnn/tiny-dnn-1.0.0a3;name=tinydnn;unpack=false \
     file://0001-3rdparty-ippicv-Use-pre-downloaded-ipp.patch \
     file://fixpkgconfig.patch \

--- a/meta-oe/recipes-support/picocom/picocom_git.bb
+++ b/meta-oe/recipes-support/picocom/picocom_git.bb
@@ -9,7 +9,7 @@ PV = "${BASEPV}+git${SRCPV}"
 
 SRCREV = "deffd18c24145bd6f965f44e735a50b65810ccdc"
 
-SRC_URI = "git://github.com/npat-efault/picocom"
+SRC_URI = "git://github.com/npat-efault/picocom;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/poco/poco_1.8.0.1.bb
+++ b/meta-oe/recipes-support/poco/poco_1.8.0.1.bb
@@ -14,7 +14,7 @@ BBCLASSEXTEND = "native"
 
 SRCREV = "af527ab21fca5ab2659285408aec9920ed7c7b17"
 SRC_URI = " \
-    git://github.com/pocoproject/poco.git \
+    git://github.com/pocoproject/poco.git;protocol=https \
     file://run-ptest \
    "
 

--- a/meta-oe/recipes-support/pps-tools/pps-tools_git.bb
+++ b/meta-oe/recipes-support/pps-tools/pps-tools_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 PV = "0.0.0+git${SRCPV}"
 SRCREV = "0deb9c7e135e9380a6d09e9d2e938a146bb698c8"
-SRC_URI = "git://github.com/ago/pps-tools.git"
+SRC_URI = "git://github.com/ago/pps-tools.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/rsnapshot/rsnapshot_git.bb
+++ b/meta-oe/recipes-support/rsnapshot/rsnapshot_git.bb
@@ -23,7 +23,7 @@ RDEPENDS_${PN} = "rsync \
 SRCREV = "27209563f924a22f510698ea225f53ea52f07cb4"
 PV = "1.4.2+git${SRCPV}"
 
-SRC_URI = "git://github.com/DrHyde/${BPN};branch=master;protocol=git \
+SRC_URI = "git://github.com/DrHyde/${BPN};branch=master;protocol=https \
            file://configure-fix-cmd_rsync.patch \
           "
 

--- a/meta-oe/recipes-support/satyr/satyr_0.23.bb
+++ b/meta-oe/recipes-support/satyr/satyr_0.23.bb
@@ -7,7 +7,7 @@ LICENSE = "GPLv2"
 
 inherit autotools-brokensep python3native pkgconfig
 
-SRC_URI = "git://github.com/abrt/satyr.git \
+SRC_URI = "git://github.com/abrt/satyr.git;protocol=https \
            file://0001-do-not-support-python2.patch \
            file://0002-fix-compile-failure-against-musl-C-library.patch \
 "

--- a/meta-oe/recipes-support/serial-utils/serial-forward_git.bb
+++ b/meta-oe/recipes-support/serial-utils/serial-forward_git.bb
@@ -6,7 +6,7 @@ SECTION = "console/devel"
 SRCREV = "07c6fdede0870edc37a8d51d033b6e7e29aa7c91"
 PV = "1.1+gitr${SRCPV}"
 
-SRC_URI = "git://github.com/freesmartphone/cornucopia.git \
+SRC_URI = "git://github.com/freesmartphone/cornucopia.git;protocol=https \
            file://0001-serial_forward-Disable-default-static-linking.patch;striplevel=3 \
           "
 S = "${WORKDIR}/git/tools/serial_forward"

--- a/meta-oe/recipes-support/spitools/spitools_git.bb
+++ b/meta-oe/recipes-support/spitools/spitools_git.bb
@@ -12,7 +12,7 @@ SRCREV = "318bcae5249722873bf58b27afdd20473c7047cc"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/cpb-/spi-tools.git;protocol=git"
+SRC_URI = "git://github.com/cpb-/spi-tools.git;protocol=https"
 
 
 inherit autotools

--- a/meta-oe/recipes-support/synergy/synergy_git.bb
+++ b/meta-oe/recipes-support/synergy/synergy_git.bb
@@ -10,7 +10,7 @@ do_unpack_extra[depends] = "unzip-native:do_populate_sysroot"
 # depends on virtual/libx11
 REQUIRED_DISTRO_FEATURES = "x11"
 
-SRC_URI = "git://github.com/symless/synergy.git;protocol=http"
+SRC_URI = "git://github.com/symless/synergy.git;protocol=http;protocol=https"
 
 # Version 1.8.8-stable
 SRCREV ?= "c30301e23424db1125664da17deb8c3aa6aec52d"

--- a/meta-oe/recipes-support/tbb/tbb.bb
+++ b/meta-oe/recipes-support/tbb/tbb.bb
@@ -10,7 +10,7 @@ PRDATE = "20170412"
 BRANCH = "tbb_2017"
 SRCREV = "a2cfdfe946933cbe38bffe1d8086ae36f06691a3"
 PV = "${PRDATE}+${SRCPV}"
-SRC_URI = "git://github.com/01org/tbb;branch=${BRANCH} \
+SRC_URI = "git://github.com/01org/tbb;branch=${BRANCH};protocol=https \
            file://cross-compile.patch \
            file://0001-mallinfo-is-glibc-specific-API-mark-it-so.patch \
            file://tbb.pc \

--- a/meta-oe/recipes-support/thin-provisioning-tools/thin-provisioning-tools_0.6.3.bb
+++ b/meta-oe/recipes-support/thin-provisioning-tools/thin-provisioning-tools_0.6.3.bb
@@ -7,7 +7,7 @@ SECTION = "devel"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/jthornber/thin-provisioning-tools \
+SRC_URI = "git://github.com/jthornber/thin-provisioning-tools;protocol=https \
            file://0001-do-not-strip-pdata_tools-at-do_install.patch \
 "
 

--- a/meta-oe/recipes-support/toscoterm/toscoterm_git.bb
+++ b/meta-oe/recipes-support/toscoterm/toscoterm_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://main.c;start_line=5;end_line=16;md5=9ae4bf20caf291afa
 
 # 0.2 version
 SRCREV = "8586d617aed19fc75f5ae1e07270752c1b2f9a30"
-SRC_URI = "git://github.com/OSSystems/toscoterm.git"
+SRC_URI = "git://github.com/OSSystems/toscoterm.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-oe/recipes-support/udisks/udisks2_2.7.6.bb
+++ b/meta-oe/recipes-support/udisks/udisks2_2.7.6.bb
@@ -19,7 +19,7 @@ DEPENDS += "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
 RDEPENDS_${PN} = "acl"
 
 SRC_URI = " \
-    git://github.com/storaged-project/udisks.git \
+    git://github.com/storaged-project/udisks.git;protocol=https \
     file://0001-data-fix-out-of-tree-build.patch \
     file://non-gnu-libc.patch \
 "

--- a/meta-oe/recipes-support/vim/vim_8.0.0983.bb
+++ b/meta-oe/recipes-support/vim/vim_8.0.0983.bb
@@ -6,7 +6,7 @@ RSUGGESTS_${PN} = "diffutils"
 LICENSE = "vim"
 LIC_FILES_CHKSUM = "file://../runtime/doc/uganda.txt;md5=eea32ac1424bba14096736a494ae9045"
 
-SRC_URI = "git://github.com/vim/vim.git \
+SRC_URI = "git://github.com/vim/vim.git;protocol=https \
            file://disable_acl_header_check.patch;patchdir=.. \
            file://vim-add-knob-whether-elf.h-are-checked.patch;patchdir=.. \
            file://CVE-2017-17087.patch;patchdir=.. \

--- a/meta-oe/recipes-support/xorg-xrdp/xorgxrdp_0.2.5.bb
+++ b/meta-oe/recipes-support/xorg-xrdp/xorgxrdp_0.2.5.bb
@@ -10,7 +10,7 @@ DEPENDS = "virtual/libx11 xserver-xorg xrdp nasm-native"
 inherit distro_features_check
 REQUIRED_DISTRO_FEATURES = "x11 pam"
 
-SRC_URI = "git://github.com/neutrinolabs/xorgxrdp.git"
+SRC_URI = "git://github.com/neutrinolabs/xorgxrdp.git;protocol=https"
 
 SRCREV = "c122544f184d4031bbae1ad80fbab554c34a9427"
 

--- a/meta-oe/recipes-support/xrdp/xrdp_0.9.4.bb
+++ b/meta-oe/recipes-support/xrdp/xrdp_0.9.4.bb
@@ -10,7 +10,7 @@ DEPENDS = "openssl virtual/libx11 libxfixes libxrandr libpam nasm-native"
 
 REQUIRED_DISTRO_FEATURES = "x11 pam"
 
-SRC_URI = "git://github.com/neutrinolabs/xrdp.git \
+SRC_URI = "git://github.com/neutrinolabs/xrdp.git;protocol=https \
            file://xrdp.sysconfig \
            file://0001-Fix-sesman.ini-and-xrdp.ini.patch \
            file://0001-Added-req_distinguished_name-in-etc-xrdp-openssl.con.patch \

--- a/meta-oe/recipes-test/fbtest/fb-test_git.bb
+++ b/meta-oe/recipes-test/fbtest/fb-test_git.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=eb723b61539feef013de476e68b5c50a"
 
 SRCREV = "063ec650960c2d79ac51f5c5f026cb05343a33e2"
-SRC_URI = "git://github.com/prpplague/fb-test-app.git"
+SRC_URI = "git://github.com/prpplague/fb-test-app.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-python/recipes-connectivity/gateone/gateone_git.bb
+++ b/meta-python/recipes-connectivity/gateone/gateone_git.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://liftoffsoftware.com/Products/GateOne"
 
 PV = "1.2+git${SRCPV}"
 SRCREV = "f7a9be46cb90f57459ebd363d24702de0e651034"
-SRC_URI = "git://github.com/liftoff/GateOne.git;branch=master \
+SRC_URI = "git://github.com/liftoff/GateOne.git;branch=master;protocol=https \
            file://gateone-avahi.service \
            file://80oe.conf.in \
            file://gateone.service.in \

--- a/meta-python/recipes-connectivity/python-txws/python-txws_0.9.1.bb
+++ b/meta-python/recipes-connectivity/python-txws/python-txws_0.9.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=76699830db7fa9e897f6a1ad05f98ec8"
 
 DEPENDS = "python-twisted python-six python-vcversioner"
 
-SRC_URI = "git://github.com/MostAwesomeDude/txWS.git"
+SRC_URI = "git://github.com/MostAwesomeDude/txWS.git;protocol=https"
 SRCREV= "88cf6d9b9b685ffa1720644bd53c742afb10a414"
 
 S = "${WORKDIR}/git"

--- a/meta-python/recipes-devtools/python/python-feedformatter.inc
+++ b/meta-python/recipes-devtools/python/python-feedformatter.inc
@@ -5,7 +5,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=258e3f39e2383fbd011035d04311008d"
 SRCREV = "7391193c83e10420b5a2d8ef846d23fc368c6d85"
 
-SRC_URI = "git://github.com/marianoguerra/feedformatter.git"
+SRC_URI = "git://github.com/marianoguerra/feedformatter.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-python/recipes-devtools/python/python3-langtable_0.0.38.bb
+++ b/meta-python/recipes-devtools/python/python3-langtable_0.0.38.bb
@@ -11,7 +11,7 @@ B = "${S}"
 
 SRCREV = "35687ca957b746f153a6872139462b1443f8cad1"
 PV = "0.0.38+git${SRCPV}"
-SRC_URI = "git://github.com/mike-fabian/langtable.git;branch=master \
+SRC_URI = "git://github.com/mike-fabian/langtable.git;branch=master;protocol=https \
 "
 
 inherit setuptools3 python3native

--- a/meta-python/recipes-devtools/python/python3-prctl_1.6.1.bb
+++ b/meta-python/recipes-devtools/python/python3-prctl_1.6.1.bb
@@ -13,7 +13,7 @@ B = "${S}"
 SRCREV = "1107d0be7bec4b28c85c62c454882d16844c930a"
 PV = "1.6.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/seveas/python-prctl;branch=master \
+SRC_URI = "git://github.com/seveas/python-prctl;branch=master;protocol=https \
            file://0001-support-cross-complication.patch \
 "
 inherit setuptools3 python3native

--- a/meta-python/recipes-extended/python-blivet/python3-blivet_2.2.0.bb
+++ b/meta-python/recipes-extended/python-blivet/python3-blivet_2.2.0.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 SRCREV = "39db82f20d8d4904c0c4dc8912e595177c59e091"
-SRC_URI = "git://github.com/rhinstaller/blivet;branch=2.2-devel \
+SRC_URI = "git://github.com/rhinstaller/blivet;branch=2.2-devel;protocol=https \
            file://0001-comment-out-selinux.patch \
            file://0002-run_program-support-timeout.patch\
            file://0003-support-infinit-timeout.patch \

--- a/meta-python/recipes-extended/python-blivet/python3-blivetgui_2.1.5.bb
+++ b/meta-python/recipes-extended/python-blivet/python3-blivetgui_2.1.5.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 SRCREV = "52ae8c000843c05abd1d8749f44bbe2e5d891d3d"
-SRC_URI = "git://github.com/rhinstaller/blivet-gui;branch=master \
+SRC_URI = "git://github.com/rhinstaller/blivet-gui;branch=master;protocol=https \
 "
 
 inherit distro_features_check

--- a/meta-python/recipes-extended/python-cson/python-cson_git.bb
+++ b/meta-python/recipes-extended/python-cson/python-cson_git.bb
@@ -8,7 +8,7 @@ SECTION = "devel/python"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7709d2635e63ab96973055a23c2a4cac"
 
 SRCREV = "f3f2898c44bb16b951d3e9f2fbf6d1c4158edda2"
-SRC_URI = "git://github.com/gt3389b/python-cson.git"
+SRC_URI = "git://github.com/gt3389b/python-cson.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-webserver/recipes-httpd/apache-mod/apache-websocket_git.bb
+++ b/meta-webserver/recipes-httpd/apache-mod/apache-websocket_git.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} += "apache2"
 
 # Original (github.com/disconnect/apache-websocket) is dead since 2012, the
 # fork contains patches from the modules ML and fixes CVE compliance issues
-SRC_URI = "git://github.com/jchampio/apache-websocket.git"
+SRC_URI = "git://github.com/jchampio/apache-websocket.git;protocol=https"
 
 SRCREV = "f5230d8c520dccf8631da94bf90c23f3c1100dcc"
 

--- a/meta-webserver/recipes-httpd/cherokee/cherokee_git.bb
+++ b/meta-webserver/recipes-httpd/cherokee/cherokee_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "unzip-native libpcre openssl mysql5 ${@bb.utils.contains('DISTRO_FEAT
 
 SRCREV = "75f041e2255e6dd0692db2f14611c2647dbe8425"
 PV = "1.2.104+git${SRCPV}"
-SRC_URI = "git://github.com/cherokee/webserver \
+SRC_URI = "git://github.com/cherokee/webserver;protocol=https \
            file://cherokee.init \
            file://cherokee.service \
            file://cherokee-install-configured.py-once.patch \

--- a/meta-xfce/recipes-apps/xarchiver/xarchiver_git.bb
+++ b/meta-xfce/recipes-apps/xarchiver/xarchiver_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 DEPENDS = "gtk+ glib-2.0 xfce4-dev-tools-native intltool-native"
 
-SRC_URI = "git://github.com/schnitzeltony/xarchiver.git;branch=master"
+SRC_URI = "git://github.com/schnitzeltony/xarchiver.git;branch=master;protocol=https"
 SRCREV = "5a26dd8ceab0af71b30c83286d7c7398a858c814"
 PV = "0.5.3"
 S = "${WORKDIR}/git"

--- a/meta-xfce/recipes-apps/xfce-polkit/xfce-polkit_0.2.bb
+++ b/meta-xfce/recipes-apps/xfce-polkit/xfce-polkit_0.2.bb
@@ -7,7 +7,7 @@ DEPENDS = "libxfce4ui polkit"
 inherit xfce-app
 
 SRC_URI = " \
-    git://github.com/ncopa/${BPN}.git \
+    git://github.com/ncopa/${BPN}.git;protocol=https \
     file://0001-fix-Name-Comment-fields.patch \
 "
 SRCREV = "6ad1ee833c9e22e4dd72a8f7d54562d046965283"

--- a/meta-xfce/recipes-panel-plugins/closebutton/xfce4-closebutton-plugin_git.bb
+++ b/meta-xfce/recipes-panel-plugins/closebutton/xfce4-closebutton-plugin_git.bb
@@ -9,7 +9,7 @@ DEPENDS += "exo-native libwnck xfconf"
 
 PV = "0.1.0+gitr${SRCPV}"
 
-SRC_URI = "git://github.com/schnitzeltony/xfce4-closebutton-plugin.git;branch=master"
+SRC_URI = "git://github.com/schnitzeltony/xfce4-closebutton-plugin.git;branch=master;protocol=https"
 SRCREV = "02b74f13ad6f639234c8db1854963038b2780a2c"
 S = "${WORKDIR}/git"
 

--- a/meta-xfce/recipes-xfce/xfce4-settings/xfce4-settings_git.bb
+++ b/meta-xfce/recipes-xfce/xfce4-settings/xfce4-settings_git.bb
@@ -13,7 +13,7 @@ REQUIRED_DISTRO_FEATURES = "x11"
 # + minor bugfixes - sent mainline but no response
 # + option to hide mousepointer for a specific (touch) input device - sent mainline but no response
 SRC_URI = " \
-    git://github.com/schnitzeltony/xfce4-settings.git;protocol=git;branch=for-oe-4.12.3 \
+    git://github.com/schnitzeltony/xfce4-settings.git;protocol=https;branch=for-oe-4.12.3 \
     file://0001-xsettings.xml-Set-default-themes.patch \
 "
 SRCREV = "b701ac8b66b83c17469dd5009da51eeb59eba442"


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 