### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/meta-oe/recipes-bsp/tbtadm/tbtadm_0.9.3.bb
+++ b/meta-oe/recipes-bsp/tbtadm/tbtadm_0.9.3.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} = "boost-filesystem"
 inherit cmake
 
 SRCREV = "fe0fa2237b971ec8baae36b785d98a772684e5e7"
-SRC_URI = "git://github.com/intel/thunderbolt-software-user-space.git \
+SRC_URI = "git://github.com/intel/thunderbolt-software-user-space.git;protocol=https \
            file://0001-tbtadm-Disable-manpage-target.patch \
            "
 

--- a/meta-python/recipes-devtools/python/python3-prctl_1.8.1.bb
+++ b/meta-python/recipes-devtools/python/python3-prctl_1.8.1.bb
@@ -13,7 +13,7 @@ B = "${S}"
 SRCREV = "5e12e398eb5c4e30d7b29b02458c76d2cc780700"
 PV = "1.8.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/seveas/python-prctl;branch=main\
+SRC_URI = "git://github.com/seveas/python-prctl;branch=main;protocol=https \
            file://0001-support-cross-complication.patch \
 "
 inherit setuptools3 python3native


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos