### PR TITLE
openvpn: distribute sample-config-files

### DIFF
--- a/meta-networking/recipes-support/openvpn/openvpn_2.5.2.bb
+++ b/meta-networking/recipes-support/openvpn/openvpn_2.5.2.bb
@@ -44,8 +44,12 @@ do_install_append() {
     install -d ${D}/${sysconfdir}/openvpn/sample
     install -m 755 ${S}/sample/sample-config-files/loopback-server  ${D}${sysconfdir}/openvpn/sample/loopback-server.conf
     install -m 755 ${S}/sample/sample-config-files/loopback-client  ${D}${sysconfdir}/openvpn/sample/loopback-client.conf
+    install -dm 755 ${D}${sysconfdir}/openvpn/sample/sample-config-files
     install -dm 755 ${D}${sysconfdir}/openvpn/sample/sample-keys
+    install -dm 755 ${D}${sysconfdir}/openvpn/sample/sample-scripts
+    install -m 644 ${S}/sample/sample-config-files/* ${D}${sysconfdir}/openvpn/sample/sample-config-files
     install -m 644 ${S}/sample/sample-keys/* ${D}${sysconfdir}/openvpn/sample/sample-keys
+    install -m 644 ${S}/sample/sample-scripts/* ${D}${sysconfdir}/openvpn/sample/sample-scripts
 
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
The openvpn tarball has additional sample config files which are
generally useful to users, and which are typically distributed in other
distros' openvpn packages.

Include these sample configs in the OE recipe.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Testing
* Built this package on my dev machine, installed it to a VM, and verified that the `openvpn-sample` package now installs these sample scripts and configs.

# Maintainership
* This patch needed some trivial rebasing before being submitted to meta-oe upstream. I have done so and submitted to the ML. I'll only complete the merge here once the upstream patch has been accepted to `master`.