### PR TITLE
xfce4-panel: upgrade 4.16.2 -> 4.16.3

### DIFF
--- a/meta-xfce/recipes-xfce/xfce4-panel/xfce4-panel_4.16.3.bb
+++ b/meta-xfce/recipes-xfce/xfce4-panel/xfce4-panel_4.16.3.bb
@@ -8,7 +8,7 @@ inherit xfce gtk-doc gobject-introspection features_check remove-libtool mime-xd
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
-SRC_URI[sha256sum] = "8634166e6f14318daec363f7e2371d49b98986f9bce313a7dd1554f30b48b5cf"
+SRC_URI[sha256sum] = "5934eaed8a76da52c29b734ccd79600255420333dd6ebd8fd9f066379af1e092"
 SRC_URI += " \
     file://0001-windowmenu-do-not-display-desktop-icon-when-no-windo.patch \
     file://0002-use-lxdm-to-replace-dm-tool.patch \


### PR DESCRIPTION
As noted in [AB#2006485](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2006485), the `xfce4-panel` program outputs critical errors when starting up:

    garcon-CRITICAL **: <timestamp>: garcon_gtk_menu_get_desktop_actions_menu: assertion 'actions != NULL' failed

This, among other extra-warning issues, was fixed by [this PR](https://gitlab.xfce.org/xfce/xfce4-panel/-/merge_requests/43) and released in [4.16.3](https://gitlab.xfce.org/xfce/xfce4-panel/-/tags/xfce4-panel-4.16.3).

The commit here is cherry picked from 2b9f0a5b9b2f44bda934b9533291992a8f841de6, which is in the upstream meta-openembedded master branch but not in hardknott(-next).

# Testing
Built a runmode image on my local dev machine and booted it in a VM that had the embedded UI enabled.
Dumped the log which previously had contained the error messages with the assertion violation, and it no longer mentioned the errors.