### PR TITLE
sshpass: upgrade 1.05 -> 1.09

### DIFF
--- a/meta-networking/recipes-connectivity/sshpass/sshpass_1.05.bb
+++ b/meta-networking/recipes-connectivity/sshpass/sshpass_1.05.bb
@@ -1,8 +1,0 @@
-PR = "${INC_PR}.0"
-
-require sshpass.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
-
-SRC_URI[md5sum] = "c52d65fdee0712af6f77eb2b60974ac7"
-SRC_URI[sha256sum] = "c3f78752a68a0c3f62efb3332cceea0c8a1f04f7cf6b46e00ec0c3000bc8483e"

--- a/meta-networking/recipes-connectivity/sshpass/sshpass_1.09.bb
+++ b/meta-networking/recipes-connectivity/sshpass/sshpass_1.09.bb
@@ -2,9 +2,11 @@ DESCRIPTION = "Non-interactive ssh password auth"
 HOMEPAGE = "http://sshpass.sourceforge.net/"
 SECTION = "console/network"
 LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 SRC_URI = "${SOURCEFORGE_MIRROR}/sshpass/sshpass-${PV}.tar.gz"
 
-INC_PR = "r0"
+SRC_URI[md5sum] = "191a9128a74d81ae36744d5deb50d164"
+SRC_URI[sha256sum] = "71746e5e057ffe9b00b44ac40453bf47091930cba96bbea8dc48717dedc49fb7"
 
 inherit autotools


### PR DESCRIPTION
Version 1.09 was released in [January 2021](https://sourceforge.net/projects/sshpass/files/sshpass/).

In addition to the version bump, this change implements some feedback from [upstream](https://lists.openembedded.org/g/openembedded-devel/topic/92655179) when I submitted our 1.05 recipe:
 - removes the use of `PR` and `INC_PR`
 - combines the two files

Some other recipes found in the [layerindex](https://layers.openembedded.org/layerindex/branch/master/recipes/?q=sshpass) also append `native nativesdk` to [`BBCLASSEXTEND`](https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-BBCLASSEXTEND). I'm unsure of the practical effect of that or whether we'd want to follow suit.