### PR TITLE
[kirkstone] gvfs: use native ssh client

### DIFF
--- a/meta-gnome/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-gnome/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,2 @@
+# An ssh native client binary is needed by the gvfs do_configure.
+BBCLASSEXTEND += "native"

--- a/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
+++ b/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
@@ -5,8 +5,15 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=05df38dd77c35ec8431f212410a3329e"
 GNOMEBASEBUILDCLASS = "meson"
 inherit gnomebase gsettings bash-completion gettext upstream-version-is-even features_check useradd
 
-DEPENDS += "libsecret glib-2.0 glib-2.0-native libgudev shadow-native \
-            gsettings-desktop-schemas dbus"
+DEPENDS += "\
+    dbus \
+    glib-2.0 \
+    glib-2.0-native \
+    gsettings-desktop-schemas \
+    libgudev \
+    libsecret \
+    shadow-native \
+"
 
 RDEPENDS:${PN} += "gsettings-desktop-schemas"
 

--- a/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
+++ b/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
@@ -12,6 +12,7 @@ DEPENDS += "\
     gsettings-desktop-schemas \
     libgudev \
     libsecret \
+    openssh-native \
     shadow-native \
 "
 


### PR DESCRIPTION
When building the meta-oe/kirkstone:gvfs recipe [1] within our pyrex container, do_configure fails with an error about `ssh` not being available in the build environment.

```
ERROR: gvfs-1.50.0-r0 do_configure: meson failed
ERROR: gvfs-1.50.0-r0 do_configure: ExecutionError('/home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/temp/run.do_configure.7290', 1, None, None)
ERROR: Logfile of failure stored in: /home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/temp/log.do_configure.7290
Log data follows:
| DEBUG: Executing python function extend_recipe_sysroot
<snip NOTES/DEBUG output>

| NOTE: Executing meson -Dbluray=false -Dgoa=false -Dgoogle=false -Dnfs=false -Dadmin=false -Dafc=false -Darchive=false -Dcdda=false -Ddnssd=false -Dfuse=false -Dgcr=false -Dhttp=false -Dgphoto2=true -Dmtp=false -Dlogind=false -Dsmb=false -Dsystemduserunitdir=no -Dtmpfilesdir=no -Dudisks2=false...
| The Meson build system
| Version: 0.61.3
| Source dir: /home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/gvfs-1.50.0
| Build dir: /home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/build
| Build type: cross build
| Project name: gvfs
| Project version: 1.50.0
| C compiler for the host machine: x86_64-nilrt-linux-gcc -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse --sysroot=/home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/recipe-sysroot (gcc 11.3.0 "x86_64-nilrt-linux-gcc (GCC) 11.3.0")
| C linker for the host machine: x86_64-nilrt-linux-gcc -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse --sysroot=/home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/recipe-sysroot ld.bfd 2.38.20220708
| C compiler for the build machine: gcc (gcc 11.2.0 "gcc (Ubuntu 11.2.0-19ubuntu1) 11.2.0")
| C linker for the build machine: gcc ld.bfd 2.38
<snip normal meson configuration output>

| Program ssh found: NO
|
| ../gvfs-1.50.0/meson.build:462:2: ERROR: Assert failed: SFTP backend requested but a ssh client is required
|
| A full log can be found at /home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/gvfs/1.50.0-r0/build/meson-logs/meson-log.txt
| ERROR: meson failed
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/usr0/fast/nilrt-kirkstone/sources/meta-openembedded/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb:do_configure) failed with exit code '1'
```

The above error is emitted from the upstream gvfs meson.build when: the `sftp` option is enabled, but the build machine does not have an `ssh` binary in its PATH [2]. AFAICT, the `sftp` option is intentionally enabled in the meta-oe gvfs recipe.

It seems like the meson.bbclass intentionally redirects meson to use native builds of some binaries [3], but not `ssh`. In fact, I don't think there is a -native ssh client in oe-core or meta-oe.

I found it strange that this recipe worked on our previous hardknott builds; but not now. Eventually, I figured out that our kirkstone pyrex-containers are using ubuntu 22.04 as their base, and for some reason the container composition didn't install an ssh client to the container - where it did previously in hardknott.

[1] https://git.openembedded.org/meta-openembedded/tree/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb?h=kirkstone

[2] https://gitlab.gnome.org/GNOME/gvfs/-/blob/master/meson.build#L458

[3] https://git.openembedded.org/openembedded-core/tree/meta/classes/meson.bbclass?h=kirkstone#n22

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2105031

This PR:
* adds the `native.bbclass` to `openssh`, so that it is available for use in the build toolchain.
* adds `openssh-native` as a `DEPENDS` of `gvfs`, so that meson can find the `ssh` binary in `sysroot-native`.

# Testing
* [x] Builds on my dev machine.

# Maintainership
* I was intending to ship this PR upstream to meta-oe, expecting that they might want me to move the openssh BBCLASSEXTEND to OE-core or have other commentary; but my email is temporarily broken. Instead of waiting, I'm going to merge this in now and we can revert/modify after getting feedback from upstream.