### PR TITLE
[kirkstone] gvfs: (correctly) obviate the ssh-client requirement

### DIFF
--- a/meta-gnome/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-gnome/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,2 +1,0 @@
-# An ssh native client binary is needed by the gvfs do_configure.
-BBCLASSEXTEND += "native"

--- a/meta-gnome/recipes-gnome/gvfs/gvfs/0001-daemon-PATH-expand-the-sftp-backend-ssh-client.patch
+++ b/meta-gnome/recipes-gnome/gvfs/gvfs/0001-daemon-PATH-expand-the-sftp-backend-ssh-client.patch
@@ -1,0 +1,60 @@
+From 8327383e262e1e7f32750a8a2d3dd708195b0f53 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 14 Dec 2022 03:05:45 -0600
+Subject: [PATCH] daemon: PATH-expand the sftp backend ssh client
+
+Meson is currently configured to search the gvfs builder's PATH for an
+ssh client, and hardcode its fullpath as the canonical ssh client for
+the gvfs sftp backend.
+
+This setup breaks in cases where the builder has a different ssh client
+from the final runtime root, or where the client's pathes differ.
+Builders using OpenEmbedded or buildroot workspaces are particularly
+affected.
+
+Instead, set SSH_PROGRAM to `ssh` so that it gets PATH-expanded at
+runtime.
+
+Closes: https://gitlab.gnome.org/GNOME/gvfs/-/issues/465
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Accepted
+* https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/157
+  * Expect upstream merge in GNOME 44
+
+---
+ daemon/meson.build | 2 +-
+ meson.build        | 4 ----
+ 2 files changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/daemon/meson.build b/daemon/meson.build
+index e20ada29..72a16890 100644
+--- a/daemon/meson.build
++++ b/daemon/meson.build
+@@ -256,7 +256,7 @@ if enable_sftp
+     '-DDEFAULT_BACKEND_TYPE=sftp',
+     '-DBACKEND_TYPES="sftp", G_VFS_TYPE_BACKEND_SFTP,',
+     '-DMAX_JOB_THREADS=1',
+-    '-DSSH_PROGRAM="@0@"'.format(ssh.full_path()),
++    '-DSSH_PROGRAM="ssh"',
+   ]
+ 
+   programs += {'gvfsd-sftp': {'sources': sources, 'dependencies': deps, 'c_args': cflags}}
+diff --git a/meson.build b/meson.build
+index 7fd67427..a84c0104 100644
+--- a/meson.build
++++ b/meson.build
+@@ -457,10 +457,6 @@ endif
+ 
+ # *** SFTP backend ***
+ enable_sftp = get_option('sftp')
+-if enable_sftp
+-  ssh = find_program('ssh', required: false)
+-  assert(ssh.found(), 'SFTP backend requested but a ssh client is required')
+-endif
+ 
+ # *** Enable development utils ***
+ enable_devel_utils = get_option('devel_utils')
+-- 
+2.38.1
+

--- a/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
+++ b/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
@@ -12,7 +12,6 @@ DEPENDS += "\
     gsettings-desktop-schemas \
     libgudev \
     libsecret \
-    openssh-native \
     shadow-native \
 "
 

--- a/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
+++ b/meta-gnome/recipes-gnome/gvfs/gvfs_1.50.0.bb
@@ -17,7 +17,10 @@ DEPENDS += "\
 
 RDEPENDS:${PN} += "gsettings-desktop-schemas"
 
-SRC_URI = "https://download.gnome.org/sources/${BPN}/${@gnome_verdir("${PV}")}/${BPN}-${PV}.tar.xz;name=archive"
+SRC_URI = "\
+    https://download.gnome.org/sources/${BPN}/${@gnome_verdir("${PV}")}/${BPN}-${PV}.tar.xz;name=archive \
+    file://0001-daemon-PATH-expand-the-sftp-backend-ssh-client.patch \
+"
 
 SRC_URI[archive.sha256sum] = "cbc2f564d2e9f00c760673f42d6803bce3e081ab7ffb4456deffffba9339b4dd"
 


### PR DESCRIPTION
I put a fix into the NI fork of meta-oe in #28, which adds an `ssh-native` subrecipe to the build, and uses it to satisfy the ssh client build requirement for the `gvfs` recipe. When I tried to upstream that patchset, I got some reasonable pushback asking why gvfs requires a native ssh at all, and in the process of defending my position, I convinced myself that I needed to upstream a change to GNOME.

So I merged [a change](https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/157) into the GNOME/gvfs upstream to PATH-expand the ssh client at runtime instead. That change can now be backported as a .patch to `meta-oe:gvfs`, until it is ingested normally by upstream revving the recipe to the GNOME 44 release.

This PR:
1. reverts the hacky ssh-client-native changes I made to fix our local gvfs builds. These patches were not accepted upstream.
2. cherry-picks my (already upstreamed) meta-oe commit to backport the gvfs config changes as a .patch

# Testing
- [x] `gvfs` builds in kirkstone using our pyrex container, which does not include an ssh client binary.

# Meta
* This commit is kirkstone-specific. No cherry-picks needed.