### PR TITLE
recipes-bsp: Add bolt

### DIFF
--- a/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
+++ b/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Thunderbolt user-space management tool"
+DESCRIPTION = "Userspace system daemon to enable security levels for Thunderbolt on GNU/Linux"
+HOMEPAGE = "https://gitlab.freedesktop.org/bolt/bolt"
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+DEPENDS = "udev polkit dbus"
+REQUIRED_DISTRO_FEATURES = "polkit"
+
+SRC_URI = "git://gitlab.freedesktop.org/bolt/bolt.git;protocol=https;branch=master"
+SRCREV = "5a8a5866a847561566499847d46a97c612b4e6dd"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig meson features_check
+
+FILES:${PN} += "${datadir}/dbus-1/* \
+                ${datadir}/polkit-1/* \
+               "


### PR DESCRIPTION
bolt is used for managing thunderbolt devices.

WI: [2093177](https://dev.azure.com/ni/DevCentral/_workitems/edit/2093177)

### Testing
Tested on PXIe-8861 connected to PXIe-8301 with a PXI-6683H in same chassis. With changes from meta-nilrt https://github.com/ni/meta-nilrt/pull/605, verified
- [x] Built `bolt` package
- [x] Tested `authorize`, `enroll`, `forget`, `list` arguments of `boltctl` work as expected

### Note
Will send this patch upstream once reviewed here.