### PR TITLE
onboard: remove gsettings inherit

### DIFF
--- a/meta-gnome/recipes-support/onboard/onboard_1.4.1.bb
+++ b/meta-gnome/recipes-support/onboard/onboard_1.4.1.bb
@@ -10,7 +10,7 @@ SRC_URI = "https://launchpad.net/onboard/1.4/${PV}/+download/${BPN}-${PV}.tar.gz
 SRC_URI[md5sum] = "1a2fbe82e934f5b37841d17ff51e80e8"
 SRC_URI[sha256sum] = "01cae1ac5b1ef1ab985bd2d2d79ded6fc99ee04b1535cc1bb191e43a231a3865"
 
-inherit features_check setuptools3-base pkgconfig gtk-icon-cache gsettings mime-xdg
+inherit features_check setuptools3-base pkgconfig gtk-icon-cache mime-xdg
 
 REQUIRED_DISTRO_FEATURES = "x11"
 


### PR DESCRIPTION
Installing the `onboard` package to kirkstone throws the following configuration error.
```
Configuring onboard.
Error opening directory “/usr/share/glib-2.0/schemas”: No such file or directory
 * pkg_run_script: package "onboard" postinst script returned status 1.
 * opkg_configure: onboard.postinst returned 1.
```

This patch:

> The gsettings bbclass adds postinst hooks to regenerate the glib-2 schemas files, on the assumption that the inheriting recipe actually contains new schemas. Onboard does not contain such things, which causes the recipe postinst to fail, in cases where no other gsettings-containing packages are installed to the system.
> 
> Remove the unneeded gsettings bbclass.

Note: This patch cannot be upstreamed at this time, because upstream has dropped the onboard recipe from meta-oe. See [NI AZDO #2491688](https://dev.azure.com/ni/DevCentral/_workitems/edit/2491688).

# Testing
* [x] Built the `onboard` recipe with this change.
* [x] Installed it to a VM and confirmed that the onboard package installation now succeeds without errors.
* [ ] Installed the new `onboard` package to a real target with embedded UI enabled and verified that the virtual keyboard actually works.