### PR TITLE
onboard: fix package compile issues

### DIFF
--- a/meta-gnome/recipes-support/onboard/onboard_1.4.1.bb
+++ b/meta-gnome/recipes-support/onboard/onboard_1.4.1.bb
@@ -10,7 +10,7 @@ SRC_URI = "https://launchpad.net/onboard/1.4/${PV}/+download/${BPN}-${PV}.tar.gz
 SRC_URI[md5sum] = "1a2fbe82e934f5b37841d17ff51e80e8"
 SRC_URI[sha256sum] = "01cae1ac5b1ef1ab985bd2d2d79ded6fc99ee04b1535cc1bb191e43a231a3865"
 
-inherit features_check setuptools3-base pkgconfig gtk-icon-cache mime-xdg
+inherit features_check distutils3 pkgconfig gtk-icon-cache gsettings mime-xdg
 
 REQUIRED_DISTRO_FEATURES = "x11"
 


### PR DESCRIPTION
A recent upstream change to inherit setuptools3-base instead of setuptools caused the compile step to do nothing, which caused the resulting package to be missing many files and be broken.

I suspect that change was driven by a desire to eliminate compile warnings about distutils support being deprecated in python 3.12 (the build currently uses python 3.10). This change restores the dependency on distutils and as a result generates the warnings again.

This change also restores the gsettings inherit. I suspect that change seemed correct when the compile was unknowingly doing nothing, but is now needed to avoid compile errors.