### PR TITLE
(RFC) bolt: change product name used for CVE checking

### DIFF
--- a/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
+++ b/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
@@ -12,6 +12,8 @@ SRCREV = "5a8a5866a847561566499847d46a97c612b4e6dd"
 
 S = "${WORKDIR}/git"
 
+CVE_PRODUCT = "freedesktop:bolt"
+
 inherit cmake pkgconfig meson features_check
 
 FILES:${PN} += "${datadir}/dbus-1/* \


### PR DESCRIPTION
This bolt product does not currently have an entry in the CVE database. However, the default cve-check logic that maps recipes to products in the CVE database is incorrectly matching this package to a different bolt product made by bolt-cms. As a result, CVE checking incorrectly reports CVEs for that product for this package.

This is just an RFC to collect any feedback before I submit this change upstream. Do not pull at this time.