### PR TITLE
Cherry-pick upstream commits to fix bolt CVE issue

### DIFF
--- a/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
+++ b/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
@@ -12,7 +12,7 @@ SRCREV = "5a8a5866a847561566499847d46a97c612b4e6dd"
 
 S = "${WORKDIR}/git"
 
-CVE_CHECK_SKIP_RECIPE = "${PN}"
+CVE_PRODUCT = "freedesktop:bolt"
 
 inherit cmake pkgconfig meson features_check
 

--- a/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
+++ b/meta-oe/recipes-bsp/bolt/bolt_0.9.5.bb
@@ -12,6 +12,8 @@ SRCREV = "5a8a5866a847561566499847d46a97c612b4e6dd"
 
 S = "${WORKDIR}/git"
 
+CVE_CHECK_SKIP_RECIPE = "${PN}"
+
 inherit cmake pkgconfig meson features_check
 
 FILES:${PN} += "${datadir}/dbus-1/* \


### PR DESCRIPTION
These upstream commits fix the issue where our bolt package was incorrectly matching to another "bolt" product and incorrectly reporting those CVEs when cve-check was enabled.

[AB#2517342](https://dev.azure.com/ni/DevCentral/_workitems/edit/2517342)