### PR TITLE
Cherry-pick upstream commit to fix apache CVE issue

### DIFF
--- a/meta-webserver/recipes-httpd/apache2/apache2_2.4.57.bb
+++ b/meta-webserver/recipes-httpd/apache2/apache2_2.4.57.bb
@@ -36,7 +36,7 @@ inherit autotools update-rc.d pkgconfig systemd update-alternatives
 
 DEPENDS = "openssl expat pcre apr apr-util apache2-native "
 
-CVE_PRODUCT = "http_server"
+CVE_PRODUCT = "apache:http_server"
 
 SSTATE_SCAN_FILES += "apxs config_vars.mk config.nice"
 


### PR DESCRIPTION
This upstream commit fixes the issue where our apache2 package was incorrectly matching to other "http_server" products and incorrectly reporting those CVEs when cve-check was enabled.

[AB#2565247](https://dev.azure.com/ni/DevCentral/_workitems/edit/2565247)