### PR TITLE
pv: Update from 1.6.20 to 1.7.0

### DIFF
--- a/meta-oe/recipes-support/pv/pv_1.7.0.bb
+++ b/meta-oe/recipes-support/pv/pv_1.7.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://doc/COPYING;md5=9c50db2589ee3ef10a9b7b2e50ce1d02"
 SRC_URI = "https://www.ivarch.com/programs/sources/${BP}.tar.bz2 \
            file://run-ptest \
 "
-SRC_URI[sha256sum] = "e831951eff0718fba9b1ef286128773b9d0e723e1fbfae88d5a3188814fdc603"
+SRC_URI[sha256sum] = "1372b41053881a05e2df10cb054304decc0233261c0aa0e96185842fa5a422ad"
 
 UPSTREAM_CHECK_URI = "http://www.ivarch.com/programs/pv.shtml"
 UPSTREAM_CHECK_REGEX = "pv-(?P<pver>\d+(\.\d+)+).tar.bz2"


### PR DESCRIPTION
I intend to use [pv](http://www.ivarch.com/programs/pv.shtml) for displaying progress during "Get Image" and "Set Image" for USB based image replication.
Existing version 1.6.20 has a bug that prevents progress bar from being displayed when `pv` is invoked from init. Version 1.7.0 fixed this issue so upgrading it to this verison.

There is a much newer version 1.8.9 but upgrading to that requires ptest related changes among other things. Since we don't really need the latest version, just upgrading to 1.7.0.

WI: [AB#2371308](https://dev.azure.com/ni/DevCentral/_workitems/edit/2371308), [AB#2372259](https://dev.azure.com/ni/DevCentral/_workitems/edit/2372259)

### Testing
- [x] `bitbake pv`
- [x] Installed `pv` on restoremode and safemode - tested it works
- [x] Installed `pv-ptest` on safemode and ran ptests. All passed
         
<img width="537" alt="image" src="https://github.com/ni/meta-openembedded/assets/8194523/497bd92c-4287-4f57-802c-a5d7ec18523c">

### Note
Intending to send this upstream but would like us to merge this PR without waiting on upstream.