### PR TITLE
sshpass: Use SPDX identified string for GPLv2

### DIFF
--- a/meta-networking/recipes-connectivity/sshpass/sshpass_1.09.bb
+++ b/meta-networking/recipes-connectivity/sshpass/sshpass_1.09.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Non-interactive ssh password auth"
 HOMEPAGE = "http://sshpass.sourceforge.net/"
 SECTION = "console/network"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tar.gz"


### PR DESCRIPTION
Fixes
QA Issue: Recipe LICENSE includes obsolete licenses GPLv2 [obsolete-license]

This commit is being cherry-picked from [here](https://github.com/openembedded/meta-openembedded/commit/bb9672b8c5a8df645f420bd0ce8092800fa61e73) since it hadn't been part of the kirkstone branch. Without this change, the build throws an obsolete license warning.