### PR TITLE
apache2: upgrade to 2.4.62 to fix CVE-2024-38476

### DIFF
--- a/meta-webserver/recipes-httpd/apache2/apache2/0002-apache2-bump-up-the-core-size-limit-if-CoreDumpDirec.patch
+++ b/meta-webserver/recipes-httpd/apache2/apache2/0002-apache2-bump-up-the-core-size-limit-if-CoreDumpDirec.patch
@@ -1,4 +1,4 @@
-From 5074ab3425e5f1e01fd9cfa2d9b7300ea1b3f38f Mon Sep 17 00:00:00 2001
+From d1f0389e699e64f3e329c0ce509f79d969a76114 Mon Sep 17 00:00:00 2001
 From: Paul Eggleton <paul.eggleton@linux.intel.com>
 Date: Tue, 17 Jul 2012 11:27:39 +0100
 Subject: [PATCH] apache2: bump up the core size limit if CoreDumpDirectory is
@@ -16,10 +16,10 @@ Note: upstreaming was discussed but there are competing desires;
  1 file changed, 19 insertions(+)
 
 diff --git a/server/core.c b/server/core.c
-index 090e397..3020090 100644
+index 843b973..3b50100 100644
 --- a/server/core.c
 +++ b/server/core.c
-@@ -5107,6 +5107,25 @@ static int core_post_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
+@@ -5143,6 +5143,25 @@ static int core_post_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
      }
      apr_pool_cleanup_register(pconf, NULL, ap_mpm_end_gen_helper,
                                apr_pool_cleanup_null);
@@ -45,6 +45,3 @@ index 090e397..3020090 100644
      return OK;
  }
  
--- 
-2.25.1
-

--- a/meta-webserver/recipes-httpd/apache2/apache2/0004-apache2-log-the-SELinux-context-at-startup.patch
+++ b/meta-webserver/recipes-httpd/apache2/apache2/0004-apache2-log-the-SELinux-context-at-startup.patch
@@ -1,4 +1,4 @@
-From abd5b40c9b094e721e91a5d75132639149d7952f Mon Sep 17 00:00:00 2001
+From b31cf12566e806e9e9c3aa01029f6bae3ada0729 Mon Sep 17 00:00:00 2001
 From: Paul Eggleton <paul.eggleton@linux.intel.com>
 Date: Tue, 17 Jul 2012 11:27:39 +0100
 Subject: [PATCH] Log the SELinux context at startup.
@@ -14,7 +14,7 @@ Note: unlikely to be any interest in this upstream
  2 files changed, 31 insertions(+)
 
 diff --git a/configure.in b/configure.in
-index 352711a..f58620f 100644
+index 6319903..bffd8a1 100644
 --- a/configure.in
 +++ b/configure.in
 @@ -514,6 +514,11 @@ gettid
@@ -30,7 +30,7 @@ index 352711a..f58620f 100644
    # On Linux before glibc 2.30, gettid() is only usable via syscall()
    AC_CACHE_CHECK([for gettid() via syscall], ap_cv_gettid,
 diff --git a/server/core.c b/server/core.c
-index 30b317e..81f145f 100644
+index 3b50100..e0c7c7f 100644
 --- a/server/core.c
 +++ b/server/core.c
 @@ -65,6 +65,10 @@
@@ -44,7 +44,7 @@ index 30b317e..81f145f 100644
  /* LimitRequestBody handling */
  #define AP_LIMIT_REQ_BODY_UNSET         ((apr_off_t) -1)
  #define AP_DEFAULT_LIMIT_REQ_BODY       ((apr_off_t) 1<<30) /* 1GB */
-@@ -5139,6 +5143,28 @@ static int core_post_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
+@@ -5162,6 +5166,28 @@ static int core_post_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
      }
  #endif
  
@@ -73,6 +73,3 @@ index 30b317e..81f145f 100644
      return OK;
  }
  
--- 
-2.40.0
-

--- a/meta-webserver/recipes-httpd/apache2/apache2/0008-Fix-perl-install-directory-to-usr-bin.patch
+++ b/meta-webserver/recipes-httpd/apache2/apache2/0008-Fix-perl-install-directory-to-usr-bin.patch
@@ -1,4 +1,4 @@
-From 443d15b91d4e4979d92405610303797663f31102 Mon Sep 17 00:00:00 2001
+From 980eadecc128bbbe1233e5d89268be24d14e1873 Mon Sep 17 00:00:00 2001
 From: echo <fei.geng@windriver.com>
 Date: Tue, 28 Apr 2009 03:11:06 +0000
 Subject: [PATCH] Fix perl install directory to /usr/bin
@@ -16,10 +16,10 @@ Signed-off-by: Changqing Li <changqing.li@windriver.com>
  1 file changed, 1 insertion(+), 4 deletions(-)
 
 diff --git a/configure.in b/configure.in
-index 4df3ff3..4eeb609 100644
+index 4ce0fee..0362f52 100644
 --- a/configure.in
 +++ b/configure.in
-@@ -903,10 +903,7 @@ AC_DEFINE_UNQUOTED(SERVER_CONFIG_FILE, "${rel_sysconfdir}/${progname}.conf",
+@@ -936,10 +936,7 @@ AC_DEFINE_UNQUOTED(SERVER_CONFIG_FILE, "${rel_sysconfdir}/${progname}.conf",
  AC_DEFINE_UNQUOTED(AP_TYPES_CONFIG_FILE, "${rel_sysconfdir}/mime.types",
  	[Location of the MIME types config file, relative to the Apache root directory])
  
@@ -31,6 +31,3 @@ index 4df3ff3..4eeb609 100644
  AC_SUBST(perlbin)
  
  dnl If we are running on BSD/OS, we need to use the BSD .include syntax.
--- 
-2.25.1
-

--- a/meta-webserver/recipes-httpd/apache2/apache2_2.4.61.bb
+++ b/meta-webserver/recipes-httpd/apache2/apache2_2.4.61.bb
@@ -27,7 +27,7 @@ SRC_URI:append:class-target = " \
            "
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bddeddfac80b2c9a882241d008bb41c3"
-SRC_URI[sha256sum] = "7b1ec7ec5635da7cb01550513215a90f8b2f52bb7c90cf3e97ede936d3e55b0f"
+SRC_URI[sha256sum] = "ea8ba86fd95bd594d15e46d25ac5bbda82ae0c9122ad93998cc539c133eaceb6"
 
 S = "${WORKDIR}/httpd-${PV}"
 

--- a/meta-webserver/recipes-httpd/apache2/apache2_2.4.62.bb
+++ b/meta-webserver/recipes-httpd/apache2/apache2_2.4.62.bb
@@ -27,7 +27,7 @@ SRC_URI:append:class-target = " \
            "
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bddeddfac80b2c9a882241d008bb41c3"
-SRC_URI[sha256sum] = "ea8ba86fd95bd594d15e46d25ac5bbda82ae0c9122ad93998cc539c133eaceb6"
+SRC_URI[sha256sum] = "674188e7bf44ced82da8db522da946849e22080d73d16c93f7f4df89e25729ec"
 
 S = "${WORKDIR}/httpd-${PV}"
 


### PR DESCRIPTION
Cherry-pick apache2 upgrades to 2.4.62 from master in order to address [CVE-2024-38476](https://nvd.nist.gov/vuln/detail/CVE-2024-38476).
Also fixes [CVE-2024-40725](https://nvd.nist.gov/vuln/detail/CVE-2024-40725) and (less relevant to us) [CVE-2024-40898](https://nvd.nist.gov/vuln/detail/CVE-2024-40898).

[AB#2847915](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2847915)

### Testing

- [x] `bitbake apache2`
- [x] validated that the CVEs mentioned above show up as patched in cve-check
- [x] `bitbake packagefeed-ni-core`
- [x] `bitbake packagegroup-ni-desirable`
- [x] `bitbake package-index && bitbake nilrt-base-system-image`
- [x] Reimaged a cRIO-9042 with the new base image and successfully booted it.
- [x] `opkg install apache2` from local feed, checked the version, and validated the default web page loads if I point a browser at the cRIO.