### PR TITLE
Onboard: Add onboard virtual keyboard

### DIFF
--- a/meta-gnome/recipes-support/onboard/onboard/0001-pypredict-lm-Define-error-API-if-platform-does-not-h.patch
+++ b/meta-gnome/recipes-support/onboard/onboard/0001-pypredict-lm-Define-error-API-if-platform-does-not-h.patch
@@ -1,0 +1,67 @@
+From 1c95f64aa342147387ce4b1b7269a5c8b34bd898 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 13 Jul 2017 09:01:04 -0700
+Subject: [PATCH] pypredict/lm: Define error API if platform does not have it
+
+error() API is not implemented across all libcs on linux
+e.g. musl does not provide it.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ Onboard/pypredict/lm/lm.cpp         |  1 -
+ Onboard/pypredict/lm/lm.h           | 13 +++++++++++++
+ Onboard/pypredict/lm/lm_dynamic.cpp |  2 --
+ 3 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/Onboard/pypredict/lm/lm.cpp b/Onboard/pypredict/lm/lm.cpp
+index 2e64296..37ae241 100644
+--- a/Onboard/pypredict/lm/lm.cpp
++++ b/Onboard/pypredict/lm/lm.cpp
+@@ -19,7 +19,6 @@
+ 
+ #include <stdlib.h>
+ #include <stdio.h>
+-#include <error.h>
+ #include <algorithm>
+ #include <cmath>
+ #include <string>
+diff --git a/Onboard/pypredict/lm/lm.h b/Onboard/pypredict/lm/lm.h
+index ed4164a..b8b63ee 100644
+--- a/Onboard/pypredict/lm/lm.h
++++ b/Onboard/pypredict/lm/lm.h
+@@ -32,6 +32,19 @@
+ #include <algorithm>
+ #include <string>
+ 
++#if defined(HAVE_ERROR_H)
++#include <error.h>
++#else
++#include <err.h>
++#define _onboard_error(S, E, F, ...) do { \
++       if (E) \
++               err(S, F ": %s", ##__VA_ARGS__, strerror(E)); \
++       else \
++               err(S, F, ##__VA_ARGS__); \
++} while(0)
++
++#define error _onboard_error
++#endif
+ 
+ // break into debugger
+ // step twice to come back out of the raise() call into known code
+diff --git a/Onboard/pypredict/lm/lm_dynamic.cpp b/Onboard/pypredict/lm/lm_dynamic.cpp
+index 7c62824..e7c7f40 100644
+--- a/Onboard/pypredict/lm/lm_dynamic.cpp
++++ b/Onboard/pypredict/lm/lm_dynamic.cpp
+@@ -17,8 +17,6 @@
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+-#include <error.h>
+-
+ #include "lm_dynamic.h"
+ 
+ using namespace std;
+-- 
+2.13.2
+

--- a/meta-gnome/recipes-support/onboard/onboard/0002-onboard-onhover-seg-fault-fix.patch
+++ b/meta-gnome/recipes-support/onboard/onboard/0002-onboard-onhover-seg-fault-fix.patch
@@ -1,0 +1,52 @@
+From: 1be95325d320122efd5dedf7437839cfcca01f7a
+From: https://github.com/void-linux/void-packages/commit/1be95325d320122efd5dedf7437839cfcca01f7a
+Date: Mon, 23 Sep 2024
+Subject: [PATCH] onboard: fix segfault when hovering over the keyboard
+
+Currently, if the mouse pointer is hovered over the Onboard keyboard, the application crashes with a segmentation fault.
+This is because the new_device_event function is not acquiring the GIL before creating a new object. This patch fixes
+the issue by acquiring the GIL before creating a new object. It also acquires the GIL before queueing the event.
+This patch is taken from the fix provided in the following link:
+https://github.com/void-linux/void-packages/commit/1be95325d320122efd5dedf7437839cfcca01f7a
+
+Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2017-10-09]
+
+--- a/Onboard/osk/osk_devices.c
++++ b/Onboard/osk/osk_devices.c
+@@ -97,13 +97,15 @@ osk_device_event_dealloc (OskDeviceEvent
+ static OskDeviceEvent*
+ new_device_event (void)
+ {
+-    OskDeviceEvent *ev = PyObject_New(OskDeviceEvent, &osk_device_event_type);
++    OskDeviceEvent *ev;
++    PyGILState_STATE gstate = PyGILState_Ensure();
++    ev = PyObject_New(OskDeviceEvent, &osk_device_event_type);
+     if (ev)
+     {
+         osk_device_event_type.tp_init((PyObject*) ev, NULL, NULL);
+-        return ev;
+     }
+-    return NULL;
++    PyGILState_Release(gstate);
++    return ev;
+ }
+ 
+ static PyObject *
+@@ -334,6 +336,7 @@ osk_devices_dealloc (OskDevices *dev)
+ static void
+ queue_event (OskDevices* dev, OskDeviceEvent* event, Bool discard_pending)
+ {
++    PyGILState_STATE state = PyGILState_Ensure ();
+     GQueue* queue = dev->event_queue;
+     if (queue)
+     {
+@@ -364,6 +367,7 @@ queue_event (OskDevices* dev, OskDeviceE
+         Py_INCREF(event);
+         g_queue_push_head(queue, event);
+     }
++    PyGILState_Release (state);
+ }
+ 
+ static gboolean idle_process_event_queue (OskDevices* dev)

--- a/meta-gnome/recipes-support/onboard/onboard_1.4.1.bb
+++ b/meta-gnome/recipes-support/onboard/onboard_1.4.1.bb
@@ -1,0 +1,36 @@
+SUMMARY = "An onscreen keyboard"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://COPYING.GPL3;md5=8521fa4dd51909b407c5150498d34f4e"
+
+DEPENDS += "gtk+3 hunspell libcanberra libxkbfile dconf python3-distutils-extra-native intltool-native"
+
+SRC_URI = "https://launchpad.net/onboard/1.4/${PV}/+download/${BPN}-${PV}.tar.gz \
+           file://0001-pypredict-lm-Define-error-API-if-platform-does-not-h.patch \
+	       file://0002-onboard-onhover-seg-fault-fix.patch \
+           "
+SRC_URI[md5sum] = "1a2fbe82e934f5b37841d17ff51e80e8"
+SRC_URI[sha256sum] = "01cae1ac5b1ef1ab985bd2d2d79ded6fc99ee04b1535cc1bb191e43a231a3865"
+
+inherit features_check setuptools3 pkgconfig gtk-icon-cache gsettings mime-xdg
+
+REQUIRED_DISTRO_FEATURES = "x11"
+
+FILES:${PN} += " \
+    ${datadir}/dbus-1 \
+    ${datadir}/icons \
+    ${datadir}/gnome-shell \
+    ${datadir}/help \
+"
+
+RDEPENDS:${PN} += " \
+    ncurses \
+    python3-dbus \
+    python3-pycairo \
+    python3-pygobject \
+"
+
+do_install:append() {
+	install -d ${D}${sysconfdir}/xdg/autostart
+
+	mv ${D}${PYTHON_SITEPACKAGES_DIR}${sysconfdir}/xdg/autostart/onboard-autostart.desktop ${D}${sysconfdir}/xdg/autostart
+}


### PR DESCRIPTION
### Summary of Changes

The PR adds the virtual keyboard "Onboard" to meta-openembedded.


### Justification
[#AB2491688](https://dev.azure.com/ni/DevCentral/_workitems/edit/2491688/) requires the keyboard to be present on scarthgap as well.

The virtual keyboard "Onboard" (present on kirkstone) had been removed from scarthgap due to build errors on python 3.12. This PR adds back the same with corrections required for python3.12.

![image](https://github.com/user-attachments/assets/f8c073f4-d8e9-48ba-b87e-cfc288b7aa87)

### Implementation
Changes that differ from kirkstone:
1. The recipe `inherit`s `setuptools3` instead of `distutils3`. This change is required since distutils3 has been deprecated in python3.12 and the compile step fails. Since the compile fails, there are no packages that get installed.
1. The recipe also installs the autostart file that gets generated at the staged folder's python site-packages folder to /etc/xdg/autostart folder. This is necessary because of the first change. `setuptools3` installs files to the site-packages folder no matter what absolute path is specified as the prefix for the installation path.
1. There is a new patch file that is now added to the recipe: `onboard_hover_seg_fault.patch`.  This patch was found online [here](https://github.com/void-linux/void-packages/commit/1be95325d320122efd5dedf7437839cfcca01f7a).
Currently, when the mouse pointer hovers on a key, the app crashes with a segmentation fault, and this is what the patch fixes.

Other required changes can be seen in [this](https://github.com/ni/meta-nilrt/pull/732) PR in the meta-nilrt layer.

The keyboard can now be launched and used just like in kirkstone.

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

Tested by installing the built IPK on a VM.
* [x] Keyboard launch
* [x] Type on keyboard by clicking on the keys
* [x] Click on other windows (like the file explorer) to test that the keyboard goes to the background
* [x] Click on any window or textbox where something can be typed to test that the keyboard is back in focus and can type


Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>