### PR TITLE
ttf-pt-sans_1.1:: Install fonts after target boots

### DIFF
--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-pt-sans_1.1.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-pt-sans_1.1.bb
@@ -26,7 +26,7 @@ do_install () {
 
 FILES:${PN} += "${datadir}"
 
-pkg_postinst:${PN} () {
+pkg_postisnt_ontarget:${PN} () {
     set -x
     for fontdir in `find $D/usr/lib/X11/fonts -type d`; do
         mkfontdir $fontdir


### PR DESCRIPTION
Our base system image build have been throwing multiple warnings about fonts not being able to find configuration files. I believe this is because the build requires access to files, such as the font cache, that are present on the target. Updating the font postinst recipe to run on the target resolves the warnings. The related tech debt item is here: https://dev.azure.com/ni/DevCentral/_workitems/edit/2812142

# Testing
Built locally and confirmed there were no font warnings.