### PR TITLE
libpwquality: set correct pam plugin directory

### DIFF
--- a/meta-oe/recipes-extended/libpwquality/libpwquality_1.4.4.bb
+++ b/meta-oe/recipes-extended/libpwquality/libpwquality_1.4.4.bb
@@ -30,12 +30,13 @@ EXTRA_OECONF += "--with-python-rev=${PYTHON_BASEVERSION} \
                  --with-python-binary=${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} \
                  --with-pythonsitedir=${PYTHON_SITEPACKAGES_DIR} \
                  --libdir=${libdir} \
+                 --with-securedir=${base_libdir}/security \
 "
 
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam', '', d)}"
 PACKAGECONFIG[pam] = "--enable-pam, --disable-pam, libpam"
 
-FILES:${PN} += "${libdir}/security/pam_pwquality.so"
-FILES:${PN}-dbg += "${libdir}/security/.debug"
-FILES:${PN}-staticdev += "${libdir}/security/pam_pwquality.a"
-FILES:${PN}-dev += "${libdir}/security/pam_pwquality.la"
+FILES:${PN} += "${base_libdir}/security/pam_pwquality.so"
+FILES:${PN}-dbg += "${base_libdir}/security/.debug"
+FILES:${PN}-staticdev += "${base_libdir}/security/pam_pwquality.a"
+FILES:${PN}-dev += "${base_libdir}/security/pam_pwquality.la"


### PR DESCRIPTION
# Summary of Changes

Fix the install location of the libpwquality PAM plugin.

[AB#2908037](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2908037)

# Implementation

git cherry-pick -x ac988457c8dc30e1cc1600c27af308b9d802b5f5

# Justification

The libpwquality PAM plugin does not work without this change. The libpwquality PAM plugin is required for SNAC mode.

# Testing

- `bitbake packagefeed-ni-core`
- I installed the resulting libpwquality package and tested that the PAM plugin worked.

@ni/rtos @amstewart