### PR TITLE
[scarthgap] tmux: Upgrade to 3.4

### DIFF
--- a/meta-oe/recipes-extended/tmux/tmux_3.4.bb
+++ b/meta-oe/recipes-extended/tmux/tmux_3.4.bb
@@ -5,11 +5,10 @@ SECTION = "console/utils"
 LICENSE = "ISC"
 LIC_FILES_CHKSUM = "file://tmux.c;beginline=3;endline=17;md5=f256b76d52e7b4d02bf19144bdaca107"
 
-DEPENDS = "ncurses libevent"
+DEPENDS = "ncurses libevent bison-native"
 
 SRC_URI = "https://github.com/tmux/tmux/releases/download/${PV}/tmux-${PV}.tar.gz"
-SRC_URI[md5sum] = "8eee5883b9f6550fa4efaad0c9ec38f3"
-SRC_URI[sha256sum] = "e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f"
+SRC_URI[sha256sum] = "551ab8dea0bf505c0ad6b7bb35ef567cdde0ccb84357df142c254f35a23e19aa"
 
 UPSTREAM_CHECK_URI = "https://github.com/tmux/tmux/releases"
 


### PR DESCRIPTION
Changes vs 3.3a are located at
https://raw.githubusercontent.com/tmux/tmux/3.4/CHANGES. However, the most pressing reason to upgrade is that tmux crashes on copy, see https://github.com/tmux/tmux/issues/3699.

tmux's config parser was rewritten to use yacc, which necessitates DEPENDS += bison-native.

drop md5sum

Signed-off-by: Rich Tollerton <rich.tollerton@ni.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>
(cherry picked from commit 9356340655b3a4f87f98be88f2d167bb2514a54c)