### PR TITLE
ttf-pt-sans_1.1: Remove references to lib/X11/fonts

### DIFF
--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-pt-sans_1.1.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-pt-sans_1.1.bb
@@ -26,12 +26,8 @@ do_install () {
 
 FILES:${PN} += "${datadir}"
 
-pkg_postisnt_ontarget:${PN} () {
+pkg_postisnt:${PN} () {
     set -x
-    for fontdir in `find $D/usr/lib/X11/fonts -type d`; do
-        mkfontdir $fontdir
-        mkfontscale $fontdir
-    done
     for fontdir in `find $D/usr/share/fonts/X11 -type d`; do
         mkfontdir $fontdir
         mkfontscale $fontdir


### PR DESCRIPTION
The font warnings and "No such file or directory" errors are all related to /usr/lib/X11/fonts. It doesn't look like this directory is being successfully created. This change removes it and reverts the previous ontarget workaround.