### PR TITLE
Revert "ttf-pt-sans_1.1:: Install fonts after target boots"

### DIFF
--- a/meta-oe/recipes-graphics/ttf-fonts/ttf-pt-sans_1.1.bb
+++ b/meta-oe/recipes-graphics/ttf-fonts/ttf-pt-sans_1.1.bb
@@ -26,7 +26,7 @@ do_install () {
 
 FILES:${PN} += "${datadir}"
 
-pkg_postisnt_ontarget:${PN} () {
+pkg_postinst:${PN} () {
     set -x
     for fontdir in `find $D/usr/lib/X11/fonts -type d`; do
         mkfontdir $fontdir


### PR DESCRIPTION
This change causes problems for read-only rootfs and does not fully resolve the font issues. Upstream is also aware of the issue.

This reverts commit 6d85db28433f01c01b9910f1a828d77ea5b0a835.