### PR TITLE
samba: Run populate-volatile.sh update in postinst

### DIFF
--- a/meta-networking/recipes-connectivity/samba/samba_4.19.8.bb
+++ b/meta-networking/recipes-connectivity/samba/samba_4.19.8.bb
@@ -353,4 +353,10 @@ RDEPENDS:${PN}-test = "\
     ${PN}-testsuite \
     "
 
+pkg_postinst_ontarget:${PN}-common() {
+    if [ -e /etc/init.d/populate-volatile.sh ]; then
+        /etc/init.d/populate-volatile.sh update
+    fi
+}
+
 ALLOW_EMPTY:${PN}-test = "1"


### PR DESCRIPTION
samba-common installs a volatiles configuration file but had not been calling populate-volatile.sh to apply the configuration. This causes samba installation to fail due to missing directories.

Call populate-volatile.sh update in samba-common's postinst which creates the required directories and enables samba to work.

---------

Calling populate-volatile.sh update in postinst seems to be the standard way as other OE packages do it as well - e.g., [libpam](https://github.com/ni/openembedded-core/blob/nilrt/master/scarthgap/meta/recipes-extended/pam/libpam_1.5.3.bb#L176).

WI: [AB#3153258](https://dev.azure.com/ni/DevCentral/_workitems/edit/3153258)

### Testing
- [x] `bitbake samba`
- [x] `opkg install samba` no longer fails
- [x] Can see directories mentioned in [volatiles configuration file](https://github.com/ni/meta-openembedded/blob/nilrt/master/scarthgap/meta-networking/recipes-connectivity/samba/samba/volatiles.03_samba#L1) being applied.
- [x] Can see `smbd` and `nmbd` processes running

### Note
- I intend to submit this upstream but due to being close to release, would like to merge this to NI repos first.
- To be cherry-picked to `nilrt/25.5/scarthgap` and `git merge -ff-only` to `nilrt/master/next`