### PR TITLE
samba: Run populate-volatile.sh update in postinst

### DIFF
--- a/meta-networking/recipes-connectivity/samba/samba_4.19.8.bb
+++ b/meta-networking/recipes-connectivity/samba/samba_4.19.8.bb
@@ -353,4 +353,10 @@ RDEPENDS:${PN}-test = "\
     ${PN}-testsuite \
     "
 
+pkg_postinst:${PN}-common() {
+    if [ -z "$D" ] && [ -e ${sysconfdir}/init.d/populate-volatile.sh ]; then
+        ${sysconfdir}/init.d/populate-volatile.sh update
+    fi
+}
+
 ALLOW_EMPTY:${PN}-test = "1"

--- a/meta-networking/recipes-connectivity/samba/samba_4.19.8.bb
+++ b/meta-networking/recipes-connectivity/samba/samba_4.19.8.bb
@@ -353,10 +353,4 @@ RDEPENDS:${PN}-test = "\
     ${PN}-testsuite \
     "
 
-pkg_postinst_ontarget:${PN}-common() {
-    if [ -e /etc/init.d/populate-volatile.sh ]; then
-        /etc/init.d/populate-volatile.sh update
-    fi
-}
-
 ALLOW_EMPTY:${PN}-test = "1"


### PR DESCRIPTION
Revert NI-specific commit https://github.com/ni/meta-openembedded/commit/0b90bc9c06e66a63ea96365aa083af942bd123b6 and cherry-pick the upstreamed [commit](https://git.openembedded.org/meta-openembedded/commit/?id=9fd087d29861383ef5b2261a97c220bd895c3142).

WI: [AB#3164689](https://dev.azure.com/ni/DevCentral/_workitems/edit/3164689)

### Testing
- [x] `bitbake samba`
- [x] Verified `populate-volatile.sh` runs when `samba-common` is installed on a running NILRT target and creates required directories.