### PR TITLE
python3-tornado: upgrade 6.4.2 -> 6.5

### DIFF
--- a/meta-python/recipes-devtools/python/python3-tornado_6.5.bb
+++ b/meta-python/recipes-devtools/python/python3-tornado_6.5.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://www.tornadoweb.org/en/stable/"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[sha256sum] = "92bad5b4746e9879fd7bf1eb21dce4e3fc5128d71601f80005afa39237ad620b"
+SRC_URI[sha256sum] = "c70c0a26d5b2d85440e4debd14a8d0b463a0cf35d92d3af05f5f1ffa8675c826"
 
 inherit pypi python_setuptools_build_meta
 


### PR DESCRIPTION
Changelog:
 https://github.com/tornadoweb/tornado/releases/tag/v6.5.0

(cherry picked from commit 4ba176bd3798365f592776c13da2dca2dd47b32a)

WI: [AB#3200667](https://dev.azure.com/ni/DevCentral/_workitems/edit/3200667)

### Testing

- [x] bitbake python3-tornado
- [x] Built oe-core feeds
- [x] Built nilrt-base-system-image
- [x] Installed python3-tornado and python3-tornado-test packages on a target, ran tests, and confirmed test results look sane (no test failures, differences compared to test results from prior python3-tornado version are limited to fail->skipped, skipped<->pass, and the addition/removal of test cases)