### PR TITLE
cjson: upgrade 1.7.18 -> 1.7.19

### DIFF
--- a/meta-oe/recipes-devtools/cjson/cjson_1.7.19.bb
+++ b/meta-oe/recipes-devtools/cjson/cjson_1.7.19.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=218947f77e8cb8e2fa02918dc41c50d0"
 SRC_URI = "git://github.com/DaveGamble/cJSON.git;branch=master;protocol=https \
            file://run-ptest \
          "
-SRCREV = "acc76239bee01d8e9c858ae2cab296704e52d916"
+SRCREV = "c859b25da02955fef659d658b8f324b5cde87be3"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
0001-allow-build-with-cmake-4.patch
refreshed for 1.7.19

(cherry picked from commit 22b9cd61a06be2f75c38db4ccb200a620771fc8d)

[Jeffrey Pautler: dropped changes to 0001-allow-build-with-cmake-4.patch
 as that file does not exist in the target branch of this cherry-pick]

WI: [AB#3292192](https://dev.azure.com/ni/DevCentral/_workitems/edit/3292192)

### Testing

- [x] bitbake cjson
- [x] Built oe-core feeds
- [x] Built nilrt-base-system-image
- [x] Installed updated cjson and cjson-ptest packages on a target, ran ptests, and confirmed all ptests passed