### PR TITLE
merge: Currency merge with upstream scarthgap branch

### DIFF
--- a/meta-networking/dynamic-layers/meta-python/recipes-connectivity/firewalld/firewalld_1.3.4.bb
+++ b/meta-networking/dynamic-layers/meta-python/recipes-connectivity/firewalld/firewalld_1.3.4.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
     file://firewalld.init \
     file://run-ptest \
 "
-SRC_URI[sha256sum] = "aba0d8ce9617b906ea4866bf0bdfb2c2d5312f53b8e9e8e9e4d49bf330da5b5e"
+SRC_URI[sha256sum] = "d33ddcc3b78fb66aea23c880deaa85a2352ae4b54af9ef796a9cd16ddc1771e5"
 
 # glib-2.0-native is needed for GSETTINGS_RULES autoconf macro from gsettings.m4
 DEPENDS = "intltool-native glib-2.0-native nftables"

--- a/meta-networking/recipes-connectivity/nanomsg/nanomsg_1.2.2.bb
+++ b/meta-networking/recipes-connectivity/nanomsg/nanomsg_1.2.2.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=587b3fd7fd291e418ff4d2b8f3904755"
 SECTION = "libs/networking"
 
 SRC_URI = "git://github.com/nanomsg/nanomsg.git;protocol=https;branch=master"
-SRCREV = "fc3f684a80151a3319446fc96083a9ff384ee4fe"
+SRCREV = "ccd7f20c1b756f7041598383baffcdc326246db7"
 
 S = "${WORKDIR}/git"
 

--- a/meta-networking/recipes-daemons/postfix/postfix_3.8.16.bb
+++ b/meta-networking/recipes-daemons/postfix/postfix_3.8.16.bb
@@ -28,7 +28,7 @@ SRC_URI = "http://ftp.porcupine.org/mirrors/postfix-release/official/postfix-${P
            file://0005-makedefs-add-lnsl-and-lresolv-to-SYSLIBS-by-default.patch \
            "
 
-SRC_URI[sha256sum] = "0fdabc9f272ee6c85781750dbd2642920701795f948f2fd3abe7b46a1f5160a9"
+SRC_URI[sha256sum] = "54244c05f71cfa22adc70506b8ef7e17cb55e18ac2595332ec629d8ea0f0e5f4"
 
 UPSTREAM_CHECK_REGEX = "postfix\-(?P<pver>3\.8(\.\d+)+).tar.gz"
 

--- a/meta-networking/recipes-protocols/frr/frr/CVE-2026-28532.patch
+++ b/meta-networking/recipes-protocols/frr/frr/CVE-2026-28532.patch
@@ -1,0 +1,309 @@
+From ea6982fe2ae7db40b0ea0ec42c283eb3b3178798 Mon Sep 17 00:00:00 2001
+From: Jafar Al-Gharaibeh <jafar@atcorp.com>
+Date: Wed, 4 Mar 2026 12:38:46 -0600
+Subject: [PATCH] ospfd: harden TE/SR TLV iteration against malformed lengths
+
+Use 32-bit counters and per-iteration TLV size bounds checks
+in OSPF TE/SR TLV parsers so malformed opaque LSAs cannot wrap
+loop accounting and advance pointers beyond the LSA buffer.
+
+- Change loop accumulators from 16-bit to 32-bit (uint32_t) to
+  prevent wraparound
+- Rework TLV iteration so pointer advancement is controlled in-loop
+- Add per-iteration guard before advancing:
+  - `tlv_size <= (len - sum)` (or `length - sum`)
+- On malformed size, parser now logs and exits/breaks the loop
+  safely instead of stepping past buffer limits
+
+Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>
+(cherry picked from commit d3e8aedb87671f38db59b0df908e25e1d4af027d)
+
+CVE: CVE-2026-28532
+Upstream-Status: Backport [https://github.com/FRRouting/frr/commit/d3e8aedb87671f38db59b0df908e25e1d4af027d]
+Signed-off-by: Ankur Tyagi <ankur.tyagi85@gmail.com>
+---
+ ospfd/ospf_sr.c | 50 ++++++++++++++++++++++++++++++--------
+ ospfd/ospf_te.c | 64 +++++++++++++++++++++++++++++++++++++++----------
+ 2 files changed, 91 insertions(+), 23 deletions(-)
+
+diff --git a/ospfd/ospf_sr.c b/ospfd/ospf_sr.c
+index e26fe6f53a..11ca362a1b 100644
+--- a/ospfd/ospf_sr.c
++++ b/ospfd/ospf_sr.c
+@@ -985,7 +985,8 @@ static struct sr_link *get_ext_link_sid(struct tlv_header *tlvh, size_t size)
+ 	struct ext_subtlv_rmt_itf_addr *rmt_itf;
+ 
+ 	struct tlv_header *sub_tlvh;
+-	uint16_t length = 0, sum = 0, i = 0;
++	uint32_t length = 0, sum = 0;
++	uint16_t i = 0;
+ 
+ 	/* Check TLV size */
+ 	if ((ntohs(tlvh->length) > size)
+@@ -1000,7 +1001,15 @@ static struct sr_link *get_ext_link_sid(struct tlv_header *tlvh, size_t size)
+ 	length = ntohs(tlvh->length) - EXT_TLV_LINK_SIZE;
+ 	sub_tlvh = (struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE
+ 					 + EXT_TLV_LINK_SIZE);
+-	for (; sum < length && sub_tlvh; sub_tlvh = TLV_HDR_NEXT(sub_tlvh)) {
++	for (; sum < length && sub_tlvh;) {
++		uint32_t tlv_size = TLV_SIZE(sub_tlvh);
++
++		if (tlv_size > length - sum) {
++			zlog_warn("Malformed Extended Link sub-TLV size %u (remaining %u)",
++				  tlv_size, length - sum);
++			break;
++		}
++
+ 		switch (ntohs(sub_tlvh->type)) {
+ 		case EXT_SUBTLV_ADJ_SID:
+ 			adj_sid = (struct ext_subtlv_adj_sid *)sub_tlvh;
+@@ -1041,7 +1050,9 @@ static struct sr_link *get_ext_link_sid(struct tlv_header *tlvh, size_t size)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(sub_tlvh);
++		sum += tlv_size;
++		if (sum < length)
++			sub_tlvh = TLV_HDR_NEXT(sub_tlvh);
+ 	}
+ 
+ 	IPV4_ADDR_COPY(&srl->itf_addr, &link->link_data);
+@@ -1062,7 +1073,7 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
+ 	struct ext_subtlv_prefix_sid *psid;
+ 
+ 	struct tlv_header *sub_tlvh;
+-	uint16_t length = 0, sum = 0;
++	uint32_t length = 0, sum = 0;
+ 
+ 	/* Check TLV size */
+ 	if ((ntohs(tlvh->length) > size)
+@@ -1077,7 +1088,15 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
+ 	length = ntohs(tlvh->length) - EXT_TLV_PREFIX_SIZE;
+ 	sub_tlvh = (struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE
+ 					 + EXT_TLV_PREFIX_SIZE);
+-	for (; sum < length && sub_tlvh; sub_tlvh = TLV_HDR_NEXT(sub_tlvh)) {
++	for (; sum < length && sub_tlvh;) {
++		uint32_t tlv_size = TLV_SIZE(sub_tlvh);
++
++		if (tlv_size > length - sum) {
++			zlog_warn("Malformed Extended Prefix sub-TLV size %u (remaining %u)",
++				  tlv_size, length - sum);
++			break;
++		}
++
+ 		switch (ntohs(sub_tlvh->type)) {
+ 		case EXT_SUBTLV_PREFIX_SID:
+ 			psid = (struct ext_subtlv_prefix_sid *)sub_tlvh;
+@@ -1102,7 +1121,9 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(sub_tlvh);
++		sum += tlv_size;
++		if (sum < length)
++			sub_tlvh = TLV_HDR_NEXT(sub_tlvh);
+ 	}
+ 
+ 	osr_debug("  |-  Found SID %u for prefix %pFX", srp->sid,
+@@ -1364,7 +1385,7 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
+ 	struct ri_sr_tlv_sid_label_range *ri_srlb = NULL;
+ 	struct ri_sr_tlv_sr_algorithm *algo = NULL;
+ 	struct sr_block srgb;
+-	uint16_t length = 0, sum = 0;
++	uint32_t length = 0, sum = 0;
+ 	uint8_t msd = 0;
+ 
+ 	osr_debug("SR (%s): Process Router Information LSA 4.0.0.%u from %pI4",
+@@ -1392,8 +1413,15 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
+ 	srgb.range_size = 0;
+ 	srgb.lower_bound = 0;
+ 
+-	for (tlvh = TLV_HDR_TOP(lsah); (sum < length) && (tlvh != NULL);
+-	     tlvh = TLV_HDR_NEXT(tlvh)) {
++	for (tlvh = TLV_HDR_TOP(lsah); (sum < length) && (tlvh != NULL);) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
++
++		if (tlv_size > length - sum) {
++			zlog_warn("Malformed RI TLV size %u (remaining %u)", tlv_size,
++				  length - sum);
++			break;
++		}
++
+ 		switch (ntohs(tlvh->type)) {
+ 		case RI_SR_TLV_SR_ALGORITHM:
+ 			algo = (struct ri_sr_tlv_sr_algorithm *)tlvh;
+@@ -1410,7 +1438,9 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < length)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Check if Segment Routing Capabilities has been found */
+diff --git a/ospfd/ospf_te.c b/ospfd/ospf_te.c
+index 1bddf97bde..8d01e4fd1d 100644
+--- a/ospfd/ospf_te.c
++++ b/ospfd/ospf_te.c
+@@ -2121,7 +2121,7 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct ls_attributes *old, attr = {};
+ 	struct tlv_header *tlvh;
+ 	void *value;
+-	uint16_t len, sum;
++	uint32_t len, sum;
+ 	uint8_t lsa_id;
+ 
+ 	/* Initialize Attribute */
+@@ -2151,11 +2151,19 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 
+ 	sum = sizeof(struct tlv_header);
+ 	/* Browse sub-TLV and fulfill Link State Attributes */
+-	for (tlvh = TLV_DATA(tlvh); sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
++	tlvh = TLV_DATA(tlvh);
++	while (sum < len) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
+ 		uint32_t val32, tab32[2];
+ 		float valf, tabf[8];
+ 		struct in_addr addr;
+ 
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed TE sub-TLV size %u (remaining %u)", tlv_size,
++				  len - sum);
++			break;
++		}
++
+ 		value = TLV_DATA(tlvh);
+ 		switch (ntohs(tlvh->type)) {
+ 		case TE_LINK_SUBTLV_LCLIF_IPADDR:
+@@ -2250,7 +2258,9 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Get corresponding Edge from Link State Data Base */
+@@ -2350,7 +2360,7 @@ static int ospf_te_delete_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct tlv_header *tlvh;
+ 	struct in_addr addr;
+ 	struct ls_edge_key key = {.family = AF_UNSPEC};
+-	uint16_t len, sum;
++	uint32_t len, sum;
+ 	uint8_t lsa_id;
+ 
+ 	/* Initialize TLV browsing */
+@@ -2362,14 +2372,25 @@ static int ospf_te_delete_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	sum = sizeof(struct tlv_header);
+ 
+ 	/* Browse sub-TLV to find Link ID */
+-	for (tlvh = TLV_DATA(tlvh); sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
++	tlvh = TLV_DATA(tlvh);
++	while (sum < len) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
++
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed TE sub-TLV size %u (remaining %u)", tlv_size,
++				  len - sum);
++			break;
++		}
++
+ 		if (ntohs(tlvh->type) == TE_LINK_SUBTLV_LCLIF_IPADDR) {
+ 			memcpy(&addr, TLV_DATA(tlvh), TE_LINK_SUBTLV_DEF_SIZE);
+ 			key.family = AF_INET;
+ 			IPV4_ADDR_COPY(&key.k.addr, &addr);
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 	if (key.family == AF_UNSPEC)
+ 		return 0;
+@@ -2444,7 +2465,7 @@ static int ospf_te_parse_ri(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct ls_node *node;
+ 	struct lsa_header *lsah = lsa->data;
+ 	struct tlv_header *tlvh;
+-	uint16_t len = 0, sum = 0;
++	uint32_t len = 0, sum = 0;
+ 
+ 	/* Get vertex / Node from LSA Advertised Router ID */
+ 	vertex = get_vertex(ted, lsa);
+@@ -2455,13 +2476,18 @@ static int ospf_te_parse_ri(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 
+ 	/* Initialize TLV browsing */
+ 	len = lsa->size - OSPF_LSA_HEADER_SIZE;
+-	for (tlvh = TLV_HDR_TOP(lsah); sum < len && tlvh;
+-	     tlvh = TLV_HDR_NEXT(tlvh)) {
++	for (tlvh = TLV_HDR_TOP(lsah); sum < len && tlvh;) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
+ 		struct ri_sr_tlv_sr_algorithm *algo;
+ 		struct ri_sr_tlv_sid_label_range *range;
+ 		struct ri_sr_tlv_node_msd *msd;
+ 		uint32_t size, lower;
+ 
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed RI TLV size %u (remaining %u)", tlv_size, len - sum);
++			break;
++		}
++
+ 		switch (ntohs(tlvh->type)) {
+ 		case RI_SR_TLV_SR_ALGORITHM:
+ 			if (TLV_BODY_SIZE(tlvh) < 1 ||
+@@ -2546,7 +2572,9 @@ static int ospf_te_parse_ri(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Vertex has been created or updated: export it */
+@@ -2758,7 +2786,8 @@ static int ospf_te_parse_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct ext_tlv_link *ext;
+ 	struct ls_edge *edge;
+ 	struct ls_attributes *atr;
+-	uint16_t len = 0, sum = 0, i;
++	uint32_t len = 0, sum = 0;
++	uint16_t i;
+ 	uint32_t label;
+ 
+ 	/* Get corresponding Edge from Link State Data Base */
+@@ -2792,11 +2821,18 @@ static int ospf_te_parse_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	len -= EXT_TLV_LINK_SIZE;
+ 	tlvh = (struct tlv_header *)((char *)(ext) + TLV_HDR_SIZE
+ 				     + EXT_TLV_LINK_SIZE);
+-	for (; sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
++	for (; sum < len;) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
+ 		struct ext_subtlv_adj_sid *adj;
+ 		struct ext_subtlv_lan_adj_sid *ladj;
+ 		struct ext_subtlv_rmt_itf_addr *rmt;
+ 
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed Extended Link sub-TLV size %u (remaining %u)",
++				  tlv_size, len - sum);
++			break;
++		}
++
+ 		switch (ntohs(tlvh->type)) {
+ 		case EXT_SUBTLV_ADJ_SID:
+ 			if (TLV_BODY_SIZE(tlvh) != EXT_SUBTLV_ADJ_SID_SIZE)
+@@ -2875,7 +2911,9 @@ static int ospf_te_parse_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Export Link State Edge if needed */

--- a/meta-networking/recipes-protocols/frr/frr_9.1.3.bb
+++ b/meta-networking/recipes-protocols/frr/frr_9.1.3.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/9.1 \
            file://CVE-2025-61099-61100-61101-61102-61103-61104-61105-61106-61107_2.patch \
            file://CVE-2025-61099-61100-61101-61102-61103-61104-61105-61106-61107_3.patch \
            file://CVE-2025-61099-61100-61101-61102-61103-61104-61105-61106-61107_4.patch \
+           file://CVE-2026-28532.patch \
            "
 
 SRCREV = "ad1766d17be022587fe05ebe1a7bf10e1b7dce19"

--- a/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
+++ b/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
@@ -17,6 +17,7 @@ SRC_URI = "http://www.thekelleys.org.uk/dnsmasq/${@['archive/', ''][float(d.getV
            file://dnsmasq-noresolvconf.service \
            file://dnsmasq-resolved.conf \
            file://CVE-2026-4891.patch \
+           file://CVE-2026-4892.patch \
 "
 SRC_URI[sha256sum] = "8f6666b542403b5ee7ccce66ea73a4a51cf19dd49392aaccd37231a2c51b303b"
 

--- a/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
+++ b/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
@@ -18,6 +18,7 @@ SRC_URI = "http://www.thekelleys.org.uk/dnsmasq/${@['archive/', ''][float(d.getV
            file://dnsmasq-resolved.conf \
            file://CVE-2026-4891.patch \
            file://CVE-2026-4892.patch \
+           file://CVE-2026-4893.patch \
 "
 SRC_URI[sha256sum] = "8f6666b542403b5ee7ccce66ea73a4a51cf19dd49392aaccd37231a2c51b303b"
 

--- a/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
+++ b/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
@@ -19,6 +19,7 @@ SRC_URI = "http://www.thekelleys.org.uk/dnsmasq/${@['archive/', ''][float(d.getV
            file://CVE-2026-4891.patch \
            file://CVE-2026-4892.patch \
            file://CVE-2026-4893.patch \
+           file://CVE-2026-5172.patch \
 "
 SRC_URI[sha256sum] = "8f6666b542403b5ee7ccce66ea73a4a51cf19dd49392aaccd37231a2c51b303b"
 

--- a/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
+++ b/meta-networking/recipes-support/dnsmasq/dnsmasq_2.90.bb
@@ -16,6 +16,7 @@ SRC_URI = "http://www.thekelleys.org.uk/dnsmasq/${@['archive/', ''][float(d.getV
            file://dnsmasq-resolvconf.service \
            file://dnsmasq-noresolvconf.service \
            file://dnsmasq-resolved.conf \
+           file://CVE-2026-4891.patch \
 "
 SRC_URI[sha256sum] = "8f6666b542403b5ee7ccce66ea73a4a51cf19dd49392aaccd37231a2c51b303b"
 

--- a/meta-networking/recipes-support/dnsmasq/files/CVE-2026-4891.patch
+++ b/meta-networking/recipes-support/dnsmasq/files/CVE-2026-4891.patch
@@ -1,0 +1,44 @@
+From 046fe2393ea47622b8e1c3e0c6dcca8347a6c431 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Wed, 25 Mar 2026 23:04:08 +0000
+Subject: [PATCH] Verify rdlen field in RRSIG packets. CVE-2026-4891
+
+Bug report from Royce M <royce@xchglabs.com>
+
+This avoids crafted packets which give a value for rdlen _less_
+then the space taken up by the fixed data and the signer's name
+and engender a negative calculated length for the signature.
+
+CVE: CVE-2026-4891
+Upstream-Status: Backport [https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=788b4e0f6c05217981b512bed4e5fea6f8855d01]
+
+Signed-off-by: Hugo SIMELIERE (Schneider Electric) <hsimeliere.opensource@witekio.com>
+---
+ src/dnssec.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/src/dnssec.c b/src/dnssec.c
+index 68f1b5d0..d32db5b4 100644
+--- a/src/dnssec.c
++++ b/src/dnssec.c
+@@ -546,10 +546,14 @@ static int validate_rrset(time_t now, struct dns_header *header, size_t plen, in
+ 
+ 	   *ttl_out = ttl;
+ 	 }
+-       
++
++      /* Don't trust rdlen not to be too small and give us a negative sig_len
++	 It has already been checked that it doesn't run us off the end
++	 of the packet. */
++      if ((sig_len = rdlen - (p - psav)) <= 0)
++	return STAT_BOGUS;
++
+       sig = p;
+-      sig_len = rdlen - (p - psav);
+-              
+       nsigttl = htonl(orig_ttl);
+       
+       hash->update(ctx, 18, psav);
+-- 
+2.43.0
+

--- a/meta-networking/recipes-support/dnsmasq/files/CVE-2026-4892.patch
+++ b/meta-networking/recipes-support/dnsmasq/files/CVE-2026-4892.patch
@@ -1,0 +1,41 @@
+From 2f029069825270a3b91eb5f50bb8477ed7f761d3 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Wed, 25 Mar 2026 23:16:35 +0000
+Subject: [PATCH] Fix buffer overflow in helper.c with large CLIDs.
+ CVE-2026-4892
+
+Bug reported bt Royce M <royce@xchglabs.com>
+
+Location: helper.c:265-270
+DHCPv6 CLIDs can be up to 65535 bytes. When --dhcp-script is configured,
+the helper hex-encodes raw CLID bytes via sprintf("%.2x") into daemon->packet (5131 bytes).
+A 1000-byte CLID writes ~3000 bytes. The helper process retains root privileges.
+
+Note: log6_packet() correctly caps CLID to 100 bytes for logging, but the helper code path was missed.
+
+CVE: CVE-2026-4892
+Upstream-Status: Backport [https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=10e6b5b83e80749cba7b090d7780b29f908f0571]
+
+Signed-off-by: Hugo SIMELIERE (Schneider Electric) <hsimeliere.opensource@witekio.com>
+---
+ src/helper.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/helper.c b/src/helper.c
+index b9da2259..3a31e618 100644
+--- a/src/helper.c
++++ b/src/helper.c
+@@ -261,8 +261,8 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
+ 		      data.hostname_len + data.ed_len + data.clid_len, 1))
+ 	continue;
+ 
+-      /* CLID into packet */
+-      for (p = daemon->packet, i = 0; i < data.clid_len; i++)
++      /* CLID into packet: limit to 100 bytes to avoid overflowing buffer. */
++      for (p = daemon->packet, i = 0; i < data.clid_len && i < 100; i++)
+ 	{
+ 	  p += sprintf(p, "%.2x", buf[i]);
+ 	  if (i != data.clid_len - 1) 
+-- 
+2.43.0
+

--- a/meta-networking/recipes-support/dnsmasq/files/CVE-2026-4893.patch
+++ b/meta-networking/recipes-support/dnsmasq/files/CVE-2026-4893.patch
@@ -1,0 +1,38 @@
+From 262aadd7a38947d2299234c8c9cf736ff6ad955d Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Wed, 25 Mar 2026 23:22:37 +0000
+Subject: [PATCH] Fix broken client subnet validation. CVE-2026-4893
+
+Bug report from Royce M <royce@xchglabs.com>
+
+Location: forward.c:713, edns0.c:421
+
+With --add-subnet enabled, process_reply() passes the OPT record
+length (~23 bytes) instead of the packet length to check_source().
+All internal bounds checks fail, and the function always returns 1.
+ECS source validation per RFC 7871 Section 9.2 is completely bypassed.
+
+CVE: CVE-2026-4893
+Upstream-Status: Backport [https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=e3a26d092e47bf1d18aeadb758e4ca35c83b5f2d]
+
+Signed-off-by: Hugo SIMELIERE (Schneider Electric) <hsimeliere.opensource@witekio.com>
+---
+ src/forward.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/forward.c b/src/forward.c
+index 32f37e40..19ff4401 100644
+--- a/src/forward.c
++++ b/src/forward.c
+@@ -710,7 +710,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
+       /* Get extended RCODE. */
+       rcode |= sizep[2] << 4;
+ 
+-      if (option_bool(OPT_CLIENT_SUBNET) && !check_source(header, plen, pheader, query_source))
++      if (option_bool(OPT_CLIENT_SUBNET) && !check_source(header, n, pheader, query_source))
+ 	{
+ 	  my_syslog(LOG_WARNING, _("discarding DNS reply: subnet option mismatch"));
+ 	  return 0;
+-- 
+2.43.0
+

--- a/meta-networking/recipes-support/dnsmasq/files/CVE-2026-5172.patch
+++ b/meta-networking/recipes-support/dnsmasq/files/CVE-2026-5172.patch
@@ -1,0 +1,39 @@
+From f158664062e049ec4604f6e772551a00575011f4 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Mon, 30 Mar 2026 16:24:33 +0100
+Subject: [PATCH] Fix buffer overflow vulnerability in extract_addresses()
+ CVE-2026-5172
+
+Thanks to Hugo Martinez Ray for spotting this.
+
+The value of rdlen for an RR can be a lie, allowing the
+call to extract_name() at rfc1025.c:952 to advance the value of p1
+past the calculated end of the record. The makes the calculation
+of bytes remaining in the RR underflow to a huge number and results
+in a massive heap OOB read and certain crash.
+
+CVE: CVE-2026-5172
+Upstream-Status: Backport [https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=073082ddc0aba7b8efa15a688d6183463b65effa]
+
+Signed-off-by: Hugo SIMELIERE (Schneider Electric) <hsimeliere.opensource@witekio.com>
+---
+ src/rfc1035.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/rfc1035.c b/src/rfc1035.c
+index 387d894a..32dc5711 100644
+--- a/src/rfc1035.c
++++ b/src/rfc1035.c
+@@ -932,7 +932,8 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
+ 			      /* Name, extract it then re-encode. */
+ 			      int len;
+ 			      
+-			      if (!extract_name(header, qlen, &p1, name, 1, 0))
++			      /* rdlen may lie, and extract_name() advances p1 past where it says the record ends. */
++			      if (!extract_name(header, qlen, &p1, name, 1, 0) || (p1 > endrr))
+ 				{
+ 				  blockdata_free(addr.rrblock.rrdata);
+ 				  return 2;
+-- 
+2.43.0
+

--- a/meta-networking/recipes-support/open-vm-tools/open-vm-tools_12.3.5.bb
+++ b/meta-networking/recipes-support/open-vm-tools/open-vm-tools_12.3.5.bb
@@ -121,6 +121,6 @@ python() {
         raise bb.parse.SkipRecipe('Requires meta-filesystems to be present to provide fuse.')
 }
 
-CVE_PRODUCT = "open-vm-tools vmware:tools"
+CVE_PRODUCT = "open-vm-tools vmware:tools vmware:open_vm_tools"
 CVE_STATUS[CVE-2014-4199] = "fixed-version: No action required. The current version (12.3.5) is not affected by the CVE which affects version 10.0.3"
 CVE_STATUS[CVE-2014-4200] = "fixed-version: No action required. The current version (12.3.5) is not affected by the CVE which affects version 10.0.3"

--- a/meta-networking/recipes-support/strongswan/strongswan/CVE-2026-35334.patch
+++ b/meta-networking/recipes-support/strongswan/strongswan/CVE-2026-35334.patch
@@ -1,0 +1,255 @@
+From c23cf29373bb25a24b952ea4c5bf7ea326b78714 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Tue, 24 Mar 2026 18:00:23 +0100
+Subject: [PATCH] gmp: Avoid crash and timing leaks in PKCS#1 v1.5 decryption
+ padding validation
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This fixes a potential crash due to a null-pointer dereference if rsadp()
+returns NULL (e.g. with an all-zero ciphertext).
+
+And it also implements the PKCS#1 v1.5 decryption padding check in
+constant time.
+
+The timing leak caused by the previous implementation was measured at
+~17.5 Î¼s at 3 GHz, which could allow a Bleichenbacher-like attack in
+LAN environments.  However, because of how RSA encryption is used in
+strongSwan, this is not that much of an issue in practice.  The mechanism
+is only used for two use cases.  One is SCEP/EST via PKCS#7 enveloped
+data.  Fortunately, this can not be triggered in significant numbers by
+an attacker.  The other use case is TLS as used by EAP methods (EAP-TLS,
+EAP-PEAP/TTLS) during the authentication.  While the cipher suites that
+use RSA encryption are still enabled by default, the TLS messages are
+wrapped in EAP and encrypted by IKE, making any kind of attack difficult.
+
+Note that the gmp plugin isn't enabled anymore by default.  And even
+before that, most setups had the openssl plugin enabled, which has
+priority over the gmp plugin.  So it's unlikely the plugin was used in
+practice.
+
+Also note that this patch doesn't modify libstrongswan's Makefile.am
+to avoid potentially requiring autotools when patching a tarball.
+
+Fixes: d615ffdcf3cd ("implement gmp_rsa_private_key.decrypt()")
+Fixes: CVE-2026-35334
+
+
+CVE: CVE-2026-35334
+Upstream-Status: Backport [https://download.strongswan.org/security/CVE-2026-35334/strongswan-5.3.1-6.0.5_gmp_rsa_decrypt_pad.patch]
+Signed-off-by: Hitendra Prajapati <hprajapati@mvista.com>
+---
+ .../plugins/gmp/gmp_rsa_private_key.c         |  54 ++++++---
+ src/libstrongswan/utils/utils.h               |   1 +
+ src/libstrongswan/utils/utils/constant_time.h | 103 ++++++++++++++++++
+ 3 files changed, 140 insertions(+), 18 deletions(-)
+ create mode 100644 src/libstrongswan/utils/utils/constant_time.h
+
+diff --git a/src/libstrongswan/plugins/gmp/gmp_rsa_private_key.c b/src/libstrongswan/plugins/gmp/gmp_rsa_private_key.c
+index 47784b6..7312fa9 100644
+--- a/src/libstrongswan/plugins/gmp/gmp_rsa_private_key.c
++++ b/src/libstrongswan/plugins/gmp/gmp_rsa_private_key.c
+@@ -495,8 +495,8 @@ METHOD(private_key_t, decrypt, bool,
+ 	private_gmp_rsa_private_key_t *this, encryption_scheme_t scheme,
+ 	void *params, chunk_t crypto, chunk_t *plain)
+ {
+-	chunk_t em, stripped;
+-	bool success = FALSE;
++	chunk_t em;
++	u_int valid, i, j, found_sep = 0, sep_index = 0, m_index;
+ 
+ 	if (scheme != ENCRYPT_RSA_PKCS1)
+ 	{
+@@ -505,33 +505,51 @@ METHOD(private_key_t, decrypt, bool,
+ 		return FALSE;
+ 	}
+ 	/* rsa decryption using PKCS#1 RSADP */
+-	stripped = em = rsadp(this, crypto);
++	em = rsadp(this, crypto);
++	if (em.len != this->k)
++	{
++		return FALSE;
++	}
+ 
+-	/* PKCS#1 v1.5 8.1 encryption-block formatting (EB = 00 || 02 || PS || 00 || D) */
++	/* PKCS#1 v1.5, RFC 8017, section 7.2.2 message structure:
++	 * EM = 00 || 02 || PS || 00 || M */
+ 
+ 	/* check for hex pattern 00 02 in decrypted message */
+-	if ((*stripped.ptr++ != 0x00) || (*(stripped.ptr++) != 0x02))
++	valid  = constant_time_eq(em.ptr[0], 0x00);
++	valid &= constant_time_eq(em.ptr[1], 0x02);
++
++	/* the plaintext data starts after first 0x00 byte */
++	for (i = 2; i < em.len; i++)
+ 	{
+-		DBG1(DBG_LIB, "incorrect padding - probably wrong rsa key");
+-		goto end;
++		u_int zero = constant_time_eq(em.ptr[i], 0x00);
++
++		sep_index = constant_time_select(i, sep_index, ~found_sep & zero);
++		found_sep |= zero;
+ 	}
+-	stripped.len -= 2;
+ 
+-	/* the plaintext data starts after first 0x00 byte */
+-	while (stripped.len-- > 0 && *stripped.ptr++ != 0x00)
++	/* make sure PS is at least eight bytes long (plus the initial bytes) */
++	valid &= constant_time_ge(sep_index, 10);
++
++	/* instead of copying the message directly, we try not to reveal the message
++	 * length i.e. where the 0x00 byte was. and since clearing a chunk is
++	 * relatively efficient, i.e. doesn't leak much, we always allocate and copy
++	 * a value and then clear it if the structure was invalid */
++	m_index = constant_time_select(sep_index + 1, 11, valid);
+ 
+-	if (stripped.len == 0)
++	*plain = chunk_alloc(this->k);
++	for (i = 0, j = 0; i < em.len; i++)
+ 	{
+-		DBG1(DBG_LIB, "no plaintext data");
+-		goto end;
++		plain->ptr[j] = em.ptr[i];
++		j += constant_time_ge(i, m_index);
+ 	}
++	plain->len = j;
+ 
+-	*plain = chunk_clone(stripped);
+-	success = TRUE;
+-
+-end:
++	if (!valid)
++	{
++		chunk_clear(plain);
++	}
+ 	chunk_clear(&em);
+-	return success;
++	return valid;
+ }
+ 
+ METHOD(private_key_t, get_keysize, int,
+diff --git a/src/libstrongswan/utils/utils.h b/src/libstrongswan/utils/utils.h
+index 42d0114..ab0be72 100644
+--- a/src/libstrongswan/utils/utils.h
++++ b/src/libstrongswan/utils/utils.h
+@@ -53,6 +53,7 @@
+ #include "utils/atomics.h"
+ #include "utils/align.h"
+ #include "utils/byteorder.h"
++#include "utils/constant_time.h"
+ #include "utils/string.h"
+ #include "utils/memory.h"
+ #include "utils/strerror.h"
+diff --git a/src/libstrongswan/utils/utils/constant_time.h b/src/libstrongswan/utils/utils/constant_time.h
+new file mode 100644
+index 0000000..0c2c6a2
+--- /dev/null
++++ b/src/libstrongswan/utils/utils/constant_time.h
+@@ -0,0 +1,103 @@
++/*
++ * Copyright (C) 2026 Tobias Brunner
++ *
++ * Copyright (C) secunet Security Networks AG
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by the
++ * Free Software Foundation; either version 2 of the License, or (at your
++ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * for more details.
++ */
++
++/**
++ * @defgroup constant_time_i constant_time
++ * @{ @ingroup constant_time_i
++ */
++
++#ifndef CONSTANT_TIME_H_
++#define CONSTANT_TIME_H_
++
++#include <stdint.h>
++
++/**
++ * Check if the given values are not equal in constant time.
++ *
++ * @param x		first value to check
++ * @param y		second value to check
++ * @return		1 if values are not equal, 0 otherwise
++ */
++static inline u_int constant_time_neq(uint32_t x, uint32_t y)
++{
++	return ((x-y) | (y-x)) >> 31;
++}
++
++/**
++ * Check if the given values are equal in constant time.
++ *
++ * @param x		first value to check
++ * @param y		second value to check
++ * @return		1 if values are equal, 0 otherwise
++ */
++static inline u_int constant_time_eq(uint32_t x, uint32_t y)
++{
++	return 1 ^ constant_time_neq(x, y);
++}
++
++/**
++ * Compare the two values and return 1 if the first argument is lower than
++ * the second in constant time.
++ *
++ * @param x		first value to check
++ * @param y		second value to check
++ * @return		1 if first value is lower than second
++ */
++static inline u_int constant_time_lt(uint32_t x, uint32_t y)
++{
++	return (x ^ ((x^y) | ((x-y) ^ y))) >> 31;
++}
++
++/**
++ * Compare the two values and return 1 if the first argument greater or equal to
++ * the second in constant time.
++ *
++ * @param x		first value to check
++ * @param y		second value to check
++ * @return		1 if first value is greater or equal to the second
++ */
++static inline u_int constant_time_ge(uint32_t x, uint32_t y)
++{
++	return 1 ^ constant_time_lt(x, y);
++}
++
++/**
++ * Return a 32-bit all bit-set mask if the given value is not 0.
++ *
++ * @param x		value to check
++ * @return		0xffffffff if value is != 0, 0 otherwise
++ */
++static inline uint32_t constant_time_mask(uint32_t x)
++{
++	return -(uint32_t)constant_time_neq(x, 0);
++}
++
++/**
++ * Select one of two values depending on whether the condition is != 0 or not.
++ * Basically equivalent to 'c ? x : y'.
++ *
++ * @param x		first value to select
++ * @param y		second value to select
++ * @param c		condition
++ * @return		x if c is != 0, y otherwise
++ */
++static inline uint32_t constant_time_select(uint32_t x, uint32_t y, uint32_t c)
++{
++	uint32_t m = constant_time_mask(c);
++	return (x & m) | (y & ~m);
++}
++
++#endif /** CONSTANT_TIME_H_ @} */
+-- 
+2.50.1
+

--- a/meta-networking/recipes-support/strongswan/strongswan_5.9.14.bb
+++ b/meta-networking/recipes-support/strongswan/strongswan_5.9.14.bb
@@ -11,6 +11,7 @@ DEPENDS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', '  tpm2-tss', 
 SRC_URI = "https://download.strongswan.org/strongswan-${PV}.tar.bz2 \
            file://CVE-2025-62291.patch \
            file://CVE-2026-25075.patch \
+           file://CVE-2026-35334.patch \
            "
 
 SRC_URI[sha256sum] = "728027ddda4cb34c67c4cec97d3ddb8c274edfbabdaeecf7e74693b54fc33678"

--- a/meta-networking/recipes-support/wireshark/files/CVE-2025-13946.patch
+++ b/meta-networking/recipes-support/wireshark/files/CVE-2025-13946.patch
@@ -1,0 +1,51 @@
+From aba1fbe6266beb6bf9b887b6eab008e4f4841c9b Mon Sep 17 00:00:00 2001
+From: AndersBroman <a.broman58@gmail.com>
+Date: Mon, 1 Dec 2025 08:41:55 +0100
+Subject: MEGACO: Handle tvb_get_uint8 returning -1
+
+When dissecting a media descriptor, handle tvb_get_uint8 returning
+-1 when searching for a left or right bracket and not finding it
+by setting the bracket offset to the end offset so that the loop
+will exit. Leaving it at -1 can cause going backwards and at worst
+infinite loops.
+
+Fix #20884
+
+(cherry picked from commit aba1fbe6266beb6bf9b887b6eab008e4f4841c9b)
+
+Co-authored-by: John Thacker <johnthacker@gmail.com>
+origin: https://gitlab.com/wireshark/wireshark/-/merge_requests/22553
+
+
+CVE: CVE-2025-13946
+Upstream-Status: Backport [https://gitlab.com/wireshark/wireshark/-/commit/aba1fbe6266beb6bf9b887b6eab008e4f4841c9b]
+Signed-off-by: Hitendra Prajapati <hprajapati@mvista.com>
+---
+ epan/dissectors/packet-megaco.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/epan/dissectors/packet-megaco.c b/epan/dissectors/packet-megaco.c
+index 327b849..abf2078 100644
+--- a/epan/dissectors/packet-megaco.c
++++ b/epan/dissectors/packet-megaco.c
+@@ -1775,8 +1775,15 @@ dissect_megaco_mediadescriptor(tvbuff_t *tvb, proto_tree *megaco_tree_command_li
+         mediaParm = find_megaco_mediaParm_names(tvb, tvb_current_offset, tokenlen);
+ 
+         tvb_LBRKT = tvb_find_guint8(tvb, tvb_next_offset , tvb_last_RBRKT, '{');
+-        tvb_next_offset = tvb_find_guint8(tvb, tvb_current_offset+1 , tvb_last_RBRKT, '}');
+-        tvb_RBRKT = tvb_next_offset;
++        if (tvb_LBRKT == -1) {
++            // Not found, use the end offset.
++            tvb_LBRKT = tvb_last_RBRKT;
++        }
++        tvb_RBRKT = tvb_find_guint8(tvb, tvb_current_offset+1 , tvb_last_RBRKT, '}');
++        if (tvb_RBRKT == -1) {
++            // Not found, use the end offset.
++            tvb_RBRKT = tvb_last_RBRKT;
++        }
+ 
+         switch ( mediaParm ){
+         case MEGACO_LOCAL_TOKEN:
+-- 
+2.50.1
+

--- a/meta-networking/recipes-support/wireshark/wireshark_4.2.14.bb
+++ b/meta-networking/recipes-support/wireshark/wireshark_4.2.14.bb
@@ -19,6 +19,7 @@ SRC_URI = "https://1.eu.dl.wireshark.org/src/all-versions/wireshark-${PV}.tar.xz
            file://CVE-2026-0962.patch \
            file://CVE-2026-3201.patch \
            file://CVE-2026-0960.patch \
+           file://CVE-2025-13946.patch \
            "
 
 UPSTREAM_CHECK_URI = "https://1.as.dl.wireshark.org/src/all-versions"

--- a/meta-oe/recipes-dbs/postgresql/files/0001-Add-support-for-RISC-V.patch
+++ b/meta-oe/recipes-dbs/postgresql/files/0001-Add-support-for-RISC-V.patch
@@ -1,7 +1,7 @@
-From ba079b8d6a50796db41bb0ddf4c22bfe022ef898 Mon Sep 17 00:00:00 2001
+From c0f5c3d176baf893658e9534256887633e18e3c4 Mon Sep 17 00:00:00 2001
 From: "Richard W.M. Jones" <rjones@redhat.com>
 Date: Sun, 20 Nov 2016 15:04:52 +0000
-Subject: [PATCH 1/5] Add support for RISC-V.
+Subject: [PATCH] Add support for RISC-V.
 
 The architecture is sufficiently similar to aarch64 that simply
 extending the existing aarch64 macro works.
@@ -38,6 +38,3 @@ index c9fa84c..9b491e8 100644
  
  
  /* S/390 and S/390x Linux (32- and 64-bit zSeries) */
--- 
-2.25.1
-

--- a/meta-oe/recipes-dbs/postgresql/files/0002-Improve-reproducibility.patch
+++ b/meta-oe/recipes-dbs/postgresql/files/0002-Improve-reproducibility.patch
@@ -1,7 +1,7 @@
-From 084cc44215c1d5e6d33bc3d2e1d24da4fc98bdcd Mon Sep 17 00:00:00 2001
+From 97d56c79bf8807563d58cb08a8c5f3e3422e8740 Mon Sep 17 00:00:00 2001
 From: Changqing Li <changqing.li@windriver.com>
 Date: Mon, 28 Dec 2020 16:38:21 +0800
-Subject: [PATCH 2/5] Improve reproducibility,
+Subject: [PATCH] Improve reproducibility,
 
 Remove build patch from binaries which pg_config do
 not record var-CC, var-CFLAGS, and configure
@@ -36,6 +36,3 @@ index 113029b..58842a6 100644
  override CPPFLAGS += -DVAL_CFLAGS_SL="\"$(CFLAGS_SL)\""
  override CPPFLAGS += -DVAL_LDFLAGS="\"$(STD_LDFLAGS)\""
  override CPPFLAGS += -DVAL_LDFLAGS_EX="\"$(LDFLAGS_EX)\""
--- 
-2.25.1
-

--- a/meta-oe/recipes-dbs/postgresql/files/0003-configure.ac-bypass-autoconf-2.69-version-check.patch
+++ b/meta-oe/recipes-dbs/postgresql/files/0003-configure.ac-bypass-autoconf-2.69-version-check.patch
@@ -1,7 +1,7 @@
-From 30b1b37d309f67ba6d58f2197bd917107bc7d56c Mon Sep 17 00:00:00 2001
+From 0a068e697b54037664eb485d1f31342f07caac0b Mon Sep 17 00:00:00 2001
 From: Yi Fan Yu <yifan.yu@windriver.com>
 Date: Fri, 5 Feb 2021 17:15:42 -0500
-Subject: [PATCH 3/5] configure.ac: bypass autoconf 2.69 version check
+Subject: [PATCH] configure.ac: bypass autoconf 2.69 version check
 
 for upgrade to autoconf 2.71
 
@@ -13,12 +13,12 @@ Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>
  1 file changed, 4 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 4f25567..b6b1eff 100644
+index 9e30e42..4a5937f 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -19,10 +19,6 @@ m4_pattern_forbid(^PGAC_)dnl to catch undefined macros
  
- AC_INIT([PostgreSQL], [16.12], [pgsql-bugs@lists.postgresql.org], [], [https://www.postgresql.org/])
+ AC_INIT([PostgreSQL], [16.14], [pgsql-bugs@lists.postgresql.org], [], [https://www.postgresql.org/])
  
 -m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
 -Untested combinations of 'autoconf' and PostgreSQL versions are not
@@ -27,6 +27,3 @@ index 4f25567..b6b1eff 100644
  AC_COPYRIGHT([Copyright (c) 1996-2023, PostgreSQL Global Development Group])
  AC_CONFIG_SRCDIR([src/backend/access/common/heaptuple.c])
  AC_CONFIG_AUX_DIR(config)
--- 
-2.40.0
-

--- a/meta-oe/recipes-dbs/postgresql/files/0004-config_info.c-not-expose-build-info.patch
+++ b/meta-oe/recipes-dbs/postgresql/files/0004-config_info.c-not-expose-build-info.patch
@@ -1,7 +1,7 @@
-From 5be3ffdf767c1efcbfd2d1be87aa83f2e37e348e Mon Sep 17 00:00:00 2001
+From 474b18fefb4adbf394b30529a11348104c077299 Mon Sep 17 00:00:00 2001
 From: Mingli Yu <mingli.yu@windriver.com>
 Date: Mon, 1 Aug 2022 15:44:38 +0800
-Subject: [PATCH 4/5] config_info.c: not expose build info
+Subject: [PATCH] config_info.c: not expose build info
 
 Don't collect the build information to fix the buildpaths issue.
 
@@ -14,7 +14,7 @@ Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
  2 files changed, 2 insertions(+), 70 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 27f382d..3dd6bb1 100644
+index 4a5937f..ece6463 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -23,7 +23,7 @@ AC_COPYRIGHT([Copyright (c) 1996-2023, PostgreSQL Global Development Group])
@@ -114,6 +114,3 @@ index 09e78a6..86e4230 100644
  	configdata[i].name = pstrdup("VERSION");
  	configdata[i].setting = pstrdup("PostgreSQL " PG_VERSION);
  	i++;
--- 
-2.25.1
-

--- a/meta-oe/recipes-dbs/postgresql/files/0005-postgresql-fix-ptest-failure-of-sysviews.patch
+++ b/meta-oe/recipes-dbs/postgresql/files/0005-postgresql-fix-ptest-failure-of-sysviews.patch
@@ -1,7 +1,7 @@
-From 1a8b94140988d2ee5ff987b0bb3e7c3e936b8c01 Mon Sep 17 00:00:00 2001
+From 83a2f0e9989269516f344fd665fa26c9828b5599 Mon Sep 17 00:00:00 2001
 From: Manoj Saun <manojsingh.saun@windriver.com>
 Date: Wed, 22 Mar 2023 08:07:26 +0000
-Subject: [PATCH 5/5] postgresql: fix ptest failure of sysviews
+Subject: [PATCH] postgresql: fix ptest failure of sysviews
 
 The patch "0001-config_info.c-not-expose-build-info.patch" hides the debug info
 in pg_config table which reduces the count of rows from pg_config and leads to
@@ -44,6 +44,3 @@ index 351e469..84c113e 100644
  
  -- We expect no cursors in this test; see also portals.sql
  select count(*) = 0 as ok from pg_cursors;
--- 
-2.25.1
-

--- a/meta-oe/recipes-dbs/postgresql/files/not-check-libperl.patch
+++ b/meta-oe/recipes-dbs/postgresql/files/not-check-libperl.patch
@@ -1,4 +1,4 @@
-From 56b830edecff1cac5f8a8a956e7a7eeef2aa7c17 Mon Sep 17 00:00:00 2001
+From 31543bddfed8882fa2d37998d966f3985fcdf351 Mon Sep 17 00:00:00 2001
 From: Changqing Li <changqing.li@windriver.com>
 Date: Tue, 27 Nov 2018 13:25:15 +0800
 Subject: [PATCH] not check libperl under cross compiling
@@ -20,10 +20,10 @@ Signed-off-by: Changqing Li <changqing.li@windriver.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure.ac b/configure.ac
-index fba79ee..7170f26 100644
+index ecdfefd..9e30e42 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2297,7 +2297,7 @@ Use --without-tcl to disable building PL/Tcl.])
+@@ -2307,7 +2307,7 @@ Use --without-tcl to disable building PL/Tcl.])
  fi
  
  # check for <perl.h>
@@ -32,6 +32,3 @@ index fba79ee..7170f26 100644
    ac_save_CPPFLAGS=$CPPFLAGS
    CPPFLAGS="$CPPFLAGS $perl_includespec"
    AC_CHECK_HEADER(perl.h, [], [AC_MSG_ERROR([header file <perl.h> is required for Perl])],
--- 
-2.34.1
-

--- a/meta-oe/recipes-dbs/postgresql/postgresql_16.14.bb
+++ b/meta-oe/recipes-dbs/postgresql/postgresql_16.14.bb
@@ -11,6 +11,6 @@ SRC_URI += "\
    file://0005-postgresql-fix-ptest-failure-of-sysviews.patch \
 "
 
-SRC_URI[sha256sum] = "b253ee949303ef5df00e24002600da4fb37e5ccfafa78718c6ea6a936b4d97f1"
+SRC_URI[sha256sum] = "f6d077142737920858ce958ccdb75c6ee137a63b5b0853c70693d401ac7e3471"
 
 CVE_STATUS[CVE-2017-8806] = "not-applicable-config: Doesn't apply to our configuration of postgresql so we can safely ignore it."

--- a/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_20240116.3.bb
+++ b/meta-oe/recipes-devtools/abseil-cpp/abseil-cpp_20240116.3.bb
@@ -55,3 +55,6 @@ ALLOW_EMPTY:${PN} = "1"
 BBCLASSEXTEND = "native nativesdk"
 
 CVE_STATUS[CVE-2025-0838] = "cpe-incorrect: The current version (20240116.3) is not affected."
+
+# Add CVE_PRODUCT to match the NVD CPE product name
+CVE_PRODUCT = "abseil:common_libraries"

--- a/meta-oe/recipes-devtools/perl/exiftool_12.72.bb
+++ b/meta-oe/recipes-devtools/perl/exiftool_12.72.bb
@@ -22,3 +22,4 @@ RDEPENDS:${PN} = " \
 "
 
 CVE_STATUS[CVE-2026-3102] = "not-applicable-platform: affects only MacOS"
+CVE_STATUS[CVE-2026-7580] = "cpe-incorrect: The current version (12.72) is not affected."

--- a/meta-oe/recipes-devtools/php/php_8.2.31.bb
+++ b/meta-oe/recipes-devtools/php/php_8.2.31.bb
@@ -34,7 +34,7 @@ SRC_URI:append:class-target = " \
           "
 
 S = "${WORKDIR}/php-${PV}"
-SRC_URI[sha256sum] = "104820b6c8fc959dde4b3342135f42bdabf246e86918a16381a17d8447c866fa"
+SRC_URI[sha256sum] = "948183fa04cf261c9b9363c02f428977b9ddf8c0bfdff8e8e1fba816ed570803"
 
 CVE_STATUS_GROUPS += "CVE_STATUS_PHP"
 CVE_STATUS_PHP[status] = "fixed-version: The name of this product is exactly the same as github.com/emlog/emlog. CVE can be safely ignored."

--- a/meta-oe/recipes-shells/dash/dash/CVE-2026-31323.patch
+++ b/meta-oe/recipes-shells/dash/dash/CVE-2026-31323.patch
@@ -1,0 +1,43 @@
+From eeebf52119df7a74ee5187268ca3030d4c701f20 Mon Sep 17 00:00:00 2001
+From: Muchen Hou <996029583@qq.com>
+Date: Mon, 13 Apr 2026 10:28:29 +0800
+Subject: [PATCH] arith: Fix CVE-2026-31323 INTMAX_MIN / -1 overflow
+
+Division and remainder currently guard against division by zero, but not
+against the signed overflow case INTMAX_MIN / -1. On affected systems
+this can trigger SIGFPE during arithmetic expansion.
+
+Add an explicit guard before evaluating division or remainder.
+
+Signed-off-by: Muchen Hou <996029583@qq.com>
+
+Merge the overflow check with the zero division check.
+
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+(cherry picked from commit 0034bfe185d3d875cebace8cb3ca5c9dabf9e0f3)
+
+CVE: CVE-2026-31323
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/utils/dash/dash.git/commit/?id=0034bfe185d3d875cebace8cb3ca5c9dabf9e0f3]
+Signed-off-by: Theo Gaige <tgaige.opensource@witekio.com>
+---
+ src/arith_yacc.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/arith_yacc.c b/src/arith_yacc.c
+index 1a087c3..b978ef0 100644
+--- a/src/arith_yacc.c
++++ b/src/arith_yacc.c
+@@ -98,8 +98,8 @@ static intmax_t do_binop(int op, intmax_t a, intmax_t b)
+ 	default:
+ 	case ARITH_REM:
+ 	case ARITH_DIV:
+-		if (!b)
+-			yyerror("division by zero");
++		if (!b || (a == INTMAX_MIN && b == -1))
++			yyerror("division error");
+ 		return op == ARITH_REM ? a % b : a / b;
+ 	case ARITH_MUL:
+ 		return a * b;
+-- 
+2.43.0
+

--- a/meta-oe/recipes-shells/dash/dash_0.5.12.bb
+++ b/meta-oe/recipes-shells/dash/dash_0.5.12.bb
@@ -7,7 +7,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b5262b4a1a1bff72b48e935531976d2e"
 
 inherit autotools update-alternatives
 
-SRC_URI = "http://gondor.apana.org.au/~herbert/${BPN}/files/${BP}.tar.gz"
+SRC_URI = "http://gondor.apana.org.au/~herbert/${BPN}/files/${BP}.tar.gz \
+           file://CVE-2026-31323.patch \
+"
+
 SRC_URI[sha256sum] = "6a474ac46e8b0b32916c4c60df694c82058d3297d8b385b74508030ca4a8f28a"
 
 CVE_PRODUCT = "dash:dash"

--- a/meta-oe/recipes-support/lcms/lcms/CVE-2026-41254_1.patch
+++ b/meta-oe/recipes-support/lcms/lcms/CVE-2026-41254_1.patch
@@ -1,0 +1,30 @@
+From 524f3df7511b49543a65a7de2a08640777c1b29c Mon Sep 17 00:00:00 2001
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Thu, 19 Feb 2026 09:07:20 +0100
+Subject: [PATCH] Fix integer overflow in CubeSize()
+
+Thanks to @zerojackyi for reporting
+
+(cherry picked from commit da6110b1d14abc394633a388209abd5ebedd7ab0)
+
+CVE: CVE-2026-41254
+Upstream-Status: Backport [https://github.com/mm2/Little-CMS/commit/da6110b1d14abc394633a388209abd5ebedd7ab0]
+Signed-off-by: Ankur Tyagi <ankur.tyagi85@gmail.com>
+---
+ src/cmslut.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmslut.c b/src/cmslut.c
+index 1ea61a8..3488d0c 100644
+--- a/src/cmslut.c
++++ b/src/cmslut.c
+@@ -460,7 +460,8 @@ void EvaluateCLUTfloatIn16(const cmsFloat32Number In[], cmsFloat32Number Out[],
+ static
+ cmsUInt32Number CubeSize(const cmsUInt32Number Dims[], cmsUInt32Number b)
+ {
+-    cmsUInt32Number rv, dim;
++    cmsUInt32Number dim;
++    cmsUInt64Number rv;
+ 
+     _cmsAssert(Dims != NULL);
+ 

--- a/meta-oe/recipes-support/lcms/lcms/CVE-2026-41254_2.patch
+++ b/meta-oe/recipes-support/lcms/lcms/CVE-2026-41254_2.patch
@@ -1,0 +1,36 @@
+From 73ffd45705d368c159bb819ab0b1a033638c3ffe Mon Sep 17 00:00:00 2001
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Thu, 12 Mar 2026 22:57:35 +0100
+Subject: [PATCH] check for overflow
+
+Thanks to Guanni Qu for detecting & reporting the issue
+
+(cherry picked from commit e0641b1828d0a1af5ecb1b11fe22f24fceefd4bc)
+
+CVE: CVE-2026-41254
+Upstream-Status: Backport [https://github.com/mm2/Little-CMS/commit/e0641b1828d0a1af5ecb1b11fe22f24fceefd4bc]
+Signed-off-by: Ankur Tyagi <ankur.tyagi85@gmail.com>
+---
+ src/cmslut.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/cmslut.c b/src/cmslut.c
+index 3488d0c..f2d0ec4 100644
+--- a/src/cmslut.c
++++ b/src/cmslut.c
+@@ -468,12 +468,12 @@ cmsUInt32Number CubeSize(const cmsUInt32Number Dims[], cmsUInt32Number b)
+     for (rv = 1; b > 0; b--) {
+ 
+         dim = Dims[b-1];
+-        if (dim <= 1) return 0;  // Error
+-
+-        rv *= dim;
++        if (dim <= 1) return 0;  
+ 
+         // Check for overflow
+         if (rv > UINT_MAX / dim) return 0;
++
++        rv *= dim;
+     }
+ 
+     // Again, prevent overflow

--- a/meta-oe/recipes-support/lcms/lcms/CVE-2026-42798.patch
+++ b/meta-oe/recipes-support/lcms/lcms/CVE-2026-42798.patch
@@ -1,0 +1,38 @@
+From e5638450eafbe2e79b4dbbf9fcbc47998cf35427 Mon Sep 17 00:00:00 2001
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Thu, 19 Feb 2026 08:48:50 +0100
+Subject: [PATCH] Fix for ParseCube integer overflow in LUT allocation
+
+thanks to @zerojackyi for reporting
+
+(cherry picked from commit 6a686019825a89b715d16671f18d049523354176)
+
+CVE: CVE-2026-42798
+Upstream-Status: Backport [https://github.com/mm2/Little-CMS/commit/6a686019825a89b715d16671f18d049523354176]
+Signed-off-by: Ankur Tyagi <ankur.tyagi85@gmail.com>
+---
+ src/cmscgats.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmscgats.c b/src/cmscgats.c
+index bccbf58..b099331 100644
+--- a/src/cmscgats.c
++++ b/src/cmscgats.c
+@@ -3128,7 +3128,16 @@ cmsBool ParseCube(cmsIT8* cube, cmsStage** Shaper, cmsStage** CLUT, char title[]
+ 
+             if (lut_size > 0) {
+ 
+-                int nodes = lut_size * lut_size * lut_size;
++                int nodes;
++                
++                /**
++                * Professional LUT‑generation tools (e.g., Nobe LutBake) list 65×65×65 as their highest supported size.                
++                */
++                if (lut_size > 65)
++                    return SynError(cube, "LUT size '%d' is over maximum of 65", lut_size);
++
++                nodes = lut_size * lut_size * lut_size;
++
+ 
+                 cmsFloat32Number* lut_table = _cmsMalloc(cube->ContextID, nodes * 3 * sizeof(cmsFloat32Number));
+                 if (lut_table == NULL) return FALSE;

--- a/meta-oe/recipes-support/lcms/lcms_2.16.bb
+++ b/meta-oe/recipes-support/lcms/lcms_2.16.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e9ce323c4b71c943a785db90142b228a"
 SRC_URI = "${SOURCEFORGE_MIRROR}/lcms/lcms2-${PV}.tar.gz \
         file://CVE-2026-41254_1.patch \
         file://CVE-2026-41254_2.patch \
+        file://CVE-2026-42798.patch \
 "
 SRC_URI[sha256sum] = "d873d34ad8b9b4cea010631f1a6228d2087475e4dc5e763eb81acc23d9d45a51"
 

--- a/meta-oe/recipes-support/lcms/lcms_2.16.bb
+++ b/meta-oe/recipes-support/lcms/lcms_2.16.bb
@@ -3,7 +3,10 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e9ce323c4b71c943a785db90142b228a"
 
-SRC_URI = "${SOURCEFORGE_MIRROR}/lcms/lcms2-${PV}.tar.gz"
+SRC_URI = "${SOURCEFORGE_MIRROR}/lcms/lcms2-${PV}.tar.gz \
+        file://CVE-2026-41254_1.patch \
+        file://CVE-2026-41254_2.patch \
+"
 SRC_URI[sha256sum] = "d873d34ad8b9b4cea010631f1a6228d2087475e4dc5e763eb81acc23d9d45a51"
 
 DEPENDS = "tiff"

--- a/meta-oe/recipes-support/libssh/libssh_0.10.6.bb
+++ b/meta-oe/recipes-support/libssh/libssh_0.10.6.bb
@@ -68,3 +68,5 @@ do_install_ptest () {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+CVE_STATUS[CVE-2025-14821] = "not-applicable-platform: only affects Windows due to loading configuration from C:\etc"

--- a/meta-oe/recipes-support/nss/nss/CVE-2026-2781.patch
+++ b/meta-oe/recipes-support/nss/nss/CVE-2026-2781.patch
@@ -1,0 +1,36 @@
+From fc8a94cca3150a59075ae3fba82ae9758df0b187 Mon Sep 17 00:00:00 2001
+From: John Schanck <jschanck@mozilla.com>
+Date: Wed, 11 Feb 2026 17:21:49 +0000
+Subject: [PATCH] Bug 2009552 - avoid integer overflow in platform-independent
+ ghash. r=#nss-reviewers
+
+Differential Revision: https://phabricator.services.mozilla.com/D278681
+
+--HG--
+branch : NSS_3_90_BRANCH
+
+CVE: CVE-2026-2781
+Upstream-Status: Backport [https://github.com/nss-dev/nss/commit/870d3b013e6b39540d14e67b3db89da5a96381bf]
+
+(cherry picked from commit 870d3b013e6b39540d14e67b3db89da5a96381bf)
+Signed-off-by: Hugo SIMELIERE (Schneider Electric) <hsimeliere.opensource@witekio.com>
+---
+ nss/lib/freebl/gcm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nss/lib/freebl/gcm.c b/nss/lib/freebl/gcm.c
+index 9ee7fc89b..d1410a9ad 100644
+--- a/nss/lib/freebl/gcm.c
++++ b/nss/lib/freebl/gcm.c
+@@ -355,7 +355,7 @@ gcmHash_Update(gcmHashContext *ghash, const unsigned char *buf,
+     unsigned int blocks;
+     SECStatus rv;
+ 
+-    ghash->cLen += (len * PR_BITS_PER_BYTE);
++    ghash->cLen += ((uint64_t)len * PR_BITS_PER_BYTE);
+ 
+     /* first deal with the current buffer of data. Try to fill it out so
+      * we can hash it */
+-- 
+2.43.0
+

--- a/meta-oe/recipes-support/nss/nss_3.98.bb
+++ b/meta-oe/recipes-support/nss/nss_3.98.bb
@@ -34,6 +34,7 @@ SRC_URI = "http://ftp.mozilla.org/pub/security/nss/releases/${VERSION_DIR}/src/$
            file://0001-freebl-add-a-configure-option-to-disable-ARM-HW-cryp.patch \
            file://CVE-2024-6602.patch \
            file://CVE-2024-6609.patch \
+           file://CVE-2026-2781.patch \
            "
 SRC_URI[sha256sum] = "f549cc33d35c0601674bfacf7c6ad683c187595eb4125b423238d3e9aa4209ce"
 

--- a/meta-oe/recipes-support/onig/onig_6.9.9.bb
+++ b/meta-oe/recipes-support/onig/onig_6.9.9.bb
@@ -33,3 +33,6 @@ do_install_ptest() {
 }
 
 PROVIDES += "oniguruma"
+
+# Add CVE_PRODUCT to match the NVD CPE product name
+CVE_PRODUCT = "oniguruma_project:oniguruma"

--- a/meta-python/recipes-devtools/python/python3-backports-zstd/0001-pyproject.toml-make-license-entries-compatible-with-.patch
+++ b/meta-python/recipes-devtools/python/python3-backports-zstd/0001-pyproject.toml-make-license-entries-compatible-with-.patch
@@ -1,0 +1,38 @@
+From 1114b0d2b60056a3690be1f7629c112cf28ce367 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=A9mie=20Dautheribes=20=28Schneider=20Electric?=
+ =?UTF-8?q?=29?= <jeremie.dautheribes@bootlin.com>
+Date: Fri, 15 May 2026 13:39:15 +0000
+Subject: [PATCH] pyproject.toml: make license entries compatible with
+ setputools v69
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The pypropject.toml uses license and license-files entries that are only
+compatible with seuptools >= v77, while Yocto Scarthgap only provides
+setuptools v69.
+
+This is the only detected impact, otherwise the do_compile/do_package work
+fine.
+
+Upstream-Status: Inappropriate [specific to OE LTS version]
+Signed-off-by: Jérémie Dautheribes (Schneider Electric) <jeremie.dautheribes@bootlin.com>
+---
+ pyproject.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index ec9a1ea..18e6816 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,8 +5,8 @@ authors = [{ name = "Rogdham", email = "contact@rogdham.net" }]
+ description = "Backport of compression.zstd"
+ readme = { file = "README.md", content-type = "text/markdown" }
+ keywords = ["backport", "backports", "pep-784", "zstd"]
+-license = "PSF-2.0"
+-license-files = ["LICENSE.txt", "LICENSE_zstd.txt"]
++license = { text = "PSF-2.0" }
++#license-files = ["LICENSE.txt"]
+ classifiers = [
+     "Development Status :: 5 - Production/Stable",
+     "Intended Audience :: Developers",

--- a/meta-python/recipes-devtools/python/python3-backports-zstd/0002-pyprojects.toml-lower-setuptools-requirements.patch
+++ b/meta-python/recipes-devtools/python/python3-backports-zstd/0002-pyprojects.toml-lower-setuptools-requirements.patch
@@ -1,0 +1,31 @@
+From 2ab6ba1d48a3d0e13382e346ba0a638548a5513e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=A9mie=20Dautheribes=20=28Schneider=20Electric?=
+ =?UTF-8?q?=29?= <jeremie.dautheribes@bootlin.com>
+Date: Tue, 19 May 2026 14:06:43 +0000
+Subject: [PATCH] pyprojects.toml: lower setuptools requirements
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Scarthgap provides setuptools v69, so adjust the requirement
+accordingly.
+
+Upstream-Status: Inappropriate [specific to OE LTS version]
+Signed-off-by: Jérémie Dautheribes (Schneider Electric) <jeremie.dautheribes@bootlin.com>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 18e6816..b5953e2 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -30,7 +30,7 @@ Source = "https://github.com/rogdham/backports.zstd"
+ #
+ 
+ [build-system]
+-requires = ["setuptools>=80"]
++requires = ["setuptools>=69"]
+ build-backend = "setuptools.build_meta"
+ 
+ [tool.setuptools.packages.find]

--- a/meta-python/recipes-devtools/python/python3-backports-zstd_1.5.0.bb
+++ b/meta-python/recipes-devtools/python/python3-backports-zstd_1.5.0.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Backport of compression.zstd"
+DESCRIPTION = "Backport of PEP-784 'adding Zstandard to the standard library'"
+HOMEPAGE = "https://github.com/Rogdham/backports.zstd/"
+LICENSE = "0BSD & PSF-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=224f30639105a6ab845e068c2d0903ff \
+                    file://LICENSE_zstd.txt;md5=85fffd6822a26cd7d2a6eeb939ada0da \
+                    file://src/c/pythoncapi-compat/COPYING;md5=f74f54822fab8814a50330e4e4578b88 \
+                    file://src/c/zstd/LICENSE;md5=0822a32f7acdbe013606746641746ee8"
+
+inherit pypi python_setuptools_build_meta
+
+SRC_URI += " \
+        file://0001-pyproject.toml-make-license-entries-compatible-with-.patch \
+        file://0002-pyprojects.toml-lower-setuptools-requirements.patch \
+"
+
+SRC_URI[sha256sum] = "a5e622a82eb183b4fbe18032755ce0a15fa9a82f2adb9b621620b91247aaedb7"
+
+PYPI_PACKAGE = "backports_zstd"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-python/recipes-devtools/python/python3-ecdsa_0.19.0.bb
+++ b/meta-python/recipes-devtools/python/python3-ecdsa_0.19.0.bb
@@ -13,6 +13,8 @@ SRC_URI += " \
 	file://CVE-2026-33936.patch \
 "
 
+CVE_PRODUCT = "python-ecdsa_project:python-ecdsa tlsfuzzer:ecdsa"
+
 RDEPENDS:${PN}-ptest += " \
 	python3-hypothesis \
 	python3-pytest \

--- a/meta-python/recipes-devtools/python/python3-grpcio-tools_1.62.2.bb
+++ b/meta-python/recipes-devtools/python/python3-grpcio-tools_1.62.2.bb
@@ -21,3 +21,5 @@ do_compile:prepend() {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+CVE_PRODUCT += "grpc:grpc"

--- a/meta-python/recipes-devtools/python/python3-grpcio_1.62.2.bb
+++ b/meta-python/recipes-devtools/python/python3-grpcio_1.62.2.bb
@@ -51,3 +51,5 @@ CLEANBROKEN = "1"
 BBCLASSEXTEND = "native nativesdk"
 
 CCACHE_DISABLE = "1"
+
+CVE_PRODUCT += "grpc:grpc"

--- a/meta-webserver/recipes-httpd/apache2/apache2_2.4.67.bb
+++ b/meta-webserver/recipes-httpd/apache2/apache2_2.4.67.bb
@@ -27,7 +27,7 @@ SRC_URI:append:class-target = " \
            "
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bddeddfac80b2c9a882241d008bb41c3"
-SRC_URI[sha256sum] = "94d7ff2b42acbb828e870ba29e4cbad48e558a79c623ad3596e4116efcfea25a"
+SRC_URI[sha256sum] = "66cd206637b0d5c446fa7dabe75fe03525da8fb55855876c46288cd88b136aa4"
 
 S = "${WORKDIR}/httpd-${PV}"
 

--- a/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-40701.patch
+++ b/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-40701.patch
@@ -1,0 +1,73 @@
+From 7abc2a59d5d65bb981be7cababb029d60c995719 Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Tue, 21 Apr 2026 14:51:41 +0400
+Subject: [PATCH] OCSP: resolve cleanup on connection close
+
+Previously, when a client SSL connection was terminated (typically due to a
+timeout) while resolving an OCSP responder, the OCSP context was freed, but
+the resolve context was not.  This resulted in use-after-free on resolve
+completion.
+
+Reported by Leo Lin.
+
+CVE: CVE-2026-40701
+Upstream-Status: Backport [https://github.com/nginx/nginx/commit/d2b8d47741820c9fb134c6731ecb40b21f3085b1]
+Signed-off-by: Theo Gaige (Schneider Electric) <tgaige.opensource@witekio.com>
+---
+ src/event/ngx_event_openssl_stapling.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/event/ngx_event_openssl_stapling.c b/src/event/ngx_event_openssl_stapling.c
+index e3fa8c4..2aaf99b 100644
+--- a/src/event/ngx_event_openssl_stapling.c
++++ b/src/event/ngx_event_openssl_stapling.c
+@@ -111,6 +111,7 @@ struct ngx_ssl_ocsp_ctx_s {
+ 
+     ngx_resolver_t              *resolver;
+     ngx_msec_t                   resolver_timeout;
++    ngx_resolver_ctx_t          *resolve;
+ 
+     ngx_msec_t                   timeout;
+ 
+@@ -1303,6 +1304,10 @@ ngx_ssl_ocsp_done(ngx_ssl_ocsp_ctx_t *ctx)
+     ngx_log_debug0(NGX_LOG_DEBUG_EVENT, ctx->log, 0,
+                    "ssl ocsp done");
+ 
++    if (ctx->resolve) {
++        ngx_resolve_name_done(ctx->resolve);
++    }
++
+     if (ctx->peer.connection) {
+         ngx_close_connection(ctx->peer.connection);
+     }
+@@ -1395,7 +1400,10 @@ ngx_ssl_ocsp_request(ngx_ssl_ocsp_ctx_t *ctx)
+         resolve->data = ctx;
+         resolve->timeout = ctx->resolver_timeout;
+ 
++        ctx->resolve = resolve;
++
+         if (ngx_resolve_name(resolve) != NGX_OK) {
++            ctx->resolve = NULL;
+             ngx_ssl_ocsp_error(ctx);
+             return;
+         }
+@@ -1484,6 +1492,7 @@ ngx_ssl_ocsp_resolve_handler(ngx_resolver_ctx_t *resolve)
+     }
+ 
+     ngx_resolve_name_done(resolve);
++    ctx->resolve = NULL;
+ 
+     ngx_ssl_ocsp_connect(ctx);
+     return;
+@@ -1491,6 +1500,8 @@ ngx_ssl_ocsp_resolve_handler(ngx_resolver_ctx_t *resolve)
+ failed:
+ 
+     ngx_resolve_name_done(resolve);
++    ctx->resolve = NULL;
++
+     ngx_ssl_ocsp_error(ctx);
+ }
+ 
+-- 
+2.43.0
+

--- a/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42934.patch
+++ b/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42934.patch
@@ -1,0 +1,79 @@
+From 9e8f535a9320a2f6bdc3ae9cf9e616ae0a29869e Mon Sep 17 00:00:00 2001
+From: David Carlier <devnexen@gmail.com>
+Date: Sun, 12 Apr 2026 07:13:23 +0100
+Subject: [PATCH] Charset: fix buffer over-read in recode_from_utf8().
+
+When a multi-byte UTF-8 character was split across 3+ single-byte
+buffers, the saved bytes continuation path had two related bugs:
+
+ngx_utf8_decode() was called with the last saved-array index instead
+of the byte count, causing it to report "incomplete" even when the
+sequence was already complete.
+
+The subsequent ngx_memcpy() used that same index as the copy length,
+reading past the input buffer boundary.
+
+CVE: CVE-2026-42934
+Upstream-Status: Backport [https://github.com/nginx/nginx/commit/54b7945961b2eaafc480d6b85d9635d0db1c126a]
+Signed-off-by: Theo Gaige (Schneider Electric) <tgaige.opensource@witekio.com>
+---
+ .../modules/ngx_http_charset_filter_module.c  | 20 ++++++-------------
+ 1 file changed, 6 insertions(+), 14 deletions(-)
+
+diff --git a/src/http/modules/ngx_http_charset_filter_module.c b/src/http/modules/ngx_http_charset_filter_module.c
+index e52b96e..7a518e3 100644
+--- a/src/http/modules/ngx_http_charset_filter_module.c
++++ b/src/http/modules/ngx_http_charset_filter_module.c
+@@ -689,7 +689,6 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+     u_char        c, *p, *src, *dst, *saved, **table;
+     uint32_t      n;
+     ngx_buf_t    *b;
+-    ngx_uint_t    i;
+     ngx_chain_t  *out, *cl, **ll;
+ 
+     src = buf->pos;
+@@ -783,18 +782,12 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pool->log, 0,
+                    "http charset utf saved: %z", ctx->saved_len);
+ 
+-    p = src;
+-
+-    for (i = ctx->saved_len; i < NGX_UTF_LEN; i++) {
+-        ctx->saved[i] = *p++;
+-
+-        if (p == buf->last) {
+-            break;
+-        }
+-    }
++    len = ngx_min(NGX_UTF_LEN - ctx->saved_len, (size_t) (buf->last - src));
++    ngx_memcpy(&ctx->saved[ctx->saved_len], src, len);
++    len += ctx->saved_len;
+ 
+     saved = ctx->saved;
+-    n = ngx_utf8_decode(&saved, i);
++    n = ngx_utf8_decode(&saved, len);
+ 
+     c = '\0';
+ 
+@@ -810,7 +803,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+ 
+         /* incomplete UTF-8 symbol */
+ 
+-        if (i < NGX_UTF_LEN) {
++        if (len < NGX_UTF_LEN) {
+             out = ngx_http_charset_get_buf(pool, ctx);
+             if (out == NULL) {
+                 return NULL;
+@@ -823,8 +816,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+             b->sync = 1;
+             b->shadow = buf;
+ 
+-            ngx_memcpy(&ctx->saved[ctx->saved_len], src, i);
+-            ctx->saved_len += i;
++            ctx->saved_len = len;
+ 
+             return out;
+         }
+-- 
+2.43.0
+

--- a/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42945.patch
+++ b/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42945.patch
@@ -1,0 +1,46 @@
+From 3d990abc5cb4adc2368da603a419c9944aaa5f65 Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Wed, 22 Apr 2026 09:39:31 +0400
+Subject: [PATCH] Rewrite: fixed escaping and possible buffer overrun
+
+The following code resulted in incorrect escaping of $1 and possible
+segfault:
+
+    location / {
+        rewrite ^(.*) /new?c=1;
+        set $myvar $1;
+        return 200 $myvar;
+    }
+
+If there were arguments in a rewrite's replacement string, the is_args flag
+was set and incorrectly never cleared.  This resulted in escaping applied
+to any captures evaluated afterwards in set or if.  Additionally buffer was
+allocated by ngx_http_script_complex_value_code() without escaping expected,
+thus this also resulted in buffer overrun and possible segfault.
+
+A similar issue was fixed in 74d939974d43.
+
+Reported by Leo Lin.
+
+CVE: CVE-2026-42945
+Upstream-Status: Backport [https://github.com/nginx/nginx/commit/524977e7c534e87e5b55739fa74601c9f1102686]
+Signed-off-by: Theo Gaige (Schneider Electric) <tgaige.opensource@witekio.com>
+---
+ src/http/ngx_http_script.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/http/ngx_http_script.c b/src/http/ngx_http_script.c
+index a2b9f1b..2ea6113 100644
+--- a/src/http/ngx_http_script.c
++++ b/src/http/ngx_http_script.c
+@@ -1202,6 +1202,7 @@ ngx_http_script_regex_end_code(ngx_http_script_engine_t *e)
+ 
+     r = e->request;
+ 
++    e->is_args = 0;
+     e->quote = 0;
+ 
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+-- 
+2.43.0
+

--- a/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42946-01.patch
+++ b/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42946-01.patch
@@ -1,0 +1,46 @@
+From 7b45e652cc7e91fbc60cbb5f41eb4608e706bc03 Mon Sep 17 00:00:00 2001
+From: Sergey Kandaurov <pluknet@nginx.com>
+Date: Wed, 29 Apr 2026 21:56:51 +0400
+Subject: [PATCH 1/2] Upstream: reset parsing state after invalid status line
+
+Previously, it was possible to start parsing headers with a wrong
+parsing state after status line was not recognized, as a fallback
+used in the scgi and uwsgi modules.
+
+Reported by Leo Lin.
+
+CVE: CVE-2026-42946
+Upstream-Status: Backport [https://github.com/nginx/nginx/commit/baef7fdac28e4e1fe26509b50b8d15603393e28e]
+Signed-off-by: Theo Gaige (Schneider Electric) <tgaige.opensource@witekio.com>
+---
+ src/http/modules/ngx_http_scgi_module.c  | 1 +
+ src/http/modules/ngx_http_uwsgi_module.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/http/modules/ngx_http_scgi_module.c b/src/http/modules/ngx_http_scgi_module.c
+index 9fc18dc..3259820 100644
+--- a/src/http/modules/ngx_http_scgi_module.c
++++ b/src/http/modules/ngx_http_scgi_module.c
+@@ -1029,6 +1029,7 @@ ngx_http_scgi_process_status_line(ngx_http_request_t *r)
+ 
+     if (rc == NGX_ERROR) {
+         u->process_header = ngx_http_scgi_process_header;
++        r->state = 0;
+         return ngx_http_scgi_process_header(r);
+     }
+ 
+diff --git a/src/http/modules/ngx_http_uwsgi_module.c b/src/http/modules/ngx_http_uwsgi_module.c
+index e4f721b..93bcad7 100644
+--- a/src/http/modules/ngx_http_uwsgi_module.c
++++ b/src/http/modules/ngx_http_uwsgi_module.c
+@@ -1257,6 +1257,7 @@ ngx_http_uwsgi_process_status_line(ngx_http_request_t *r)
+ 
+     if (rc == NGX_ERROR) {
+         u->process_header = ngx_http_uwsgi_process_header;
++        r->state = 0;
+         return ngx_http_uwsgi_process_header(r);
+     }
+ 
+-- 
+2.43.0
+

--- a/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42946-02.patch
+++ b/meta-webserver/recipes-httpd/nginx/nginx-1.24.0/CVE-2026-42946-02.patch
@@ -1,0 +1,91 @@
+From 7b5bea14a2a7a784751a8f86559bd3c3f109ed5b Mon Sep 17 00:00:00 2001
+From: Sergey Kandaurov <pluknet@nginx.com>
+Date: Wed, 29 Apr 2026 23:02:20 +0400
+Subject: [PATCH 2/2] Upstream: fixed parsing of split status lines
+
+If the first response line was split across reads and it didn't appear
+a status line, the portion already processed was lost.  To preserve ABI,
+the change reuses r->header_name_start for proper backtracking on status
+line fallback.
+
+CVE: CVE-2026-42946
+Upstream-Status: Backport [https://github.com/nginx/nginx/commit/39d7d0ba0799fcff6baee52b6525f45739593cfd]
+Signed-off-by: Theo Gaige (Schneider Electric) <tgaige.opensource@witekio.com>
+---
+ src/http/modules/ngx_http_proxy_module.c | 5 +++++
+ src/http/modules/ngx_http_scgi_module.c  | 5 +++++
+ src/http/modules/ngx_http_uwsgi_module.c | 5 +++++
+ 3 files changed, 15 insertions(+)
+
+diff --git a/src/http/modules/ngx_http_proxy_module.c b/src/http/modules/ngx_http_proxy_module.c
+index 9cc202c..19cbfa3 100644
+--- a/src/http/modules/ngx_http_proxy_module.c
++++ b/src/http/modules/ngx_http_proxy_module.c
+@@ -1814,6 +1814,10 @@ ngx_http_proxy_process_status_line(ngx_http_request_t *r)
+ 
+     u = r->upstream;
+ 
++    if (r->state == 0) {
++        r->header_name_start = u->buffer.pos;
++    }
++
+     rc = ngx_http_parse_status_line(r, &u->buffer, &ctx->status);
+ 
+     if (rc == NGX_AGAIN) {
+@@ -1821,6 +1825,7 @@ ngx_http_proxy_process_status_line(ngx_http_request_t *r)
+     }
+ 
+     if (rc == NGX_ERROR) {
++        u->buffer.pos = r->header_name_start;
+ 
+ #if (NGX_HTTP_CACHE)
+ 
+diff --git a/src/http/modules/ngx_http_scgi_module.c b/src/http/modules/ngx_http_scgi_module.c
+index 3259820..a04fd47 100644
+--- a/src/http/modules/ngx_http_scgi_module.c
++++ b/src/http/modules/ngx_http_scgi_module.c
+@@ -1021,6 +1021,10 @@ ngx_http_scgi_process_status_line(ngx_http_request_t *r)
+ 
+     u = r->upstream;
+ 
++    if (r->state == 0) {
++        r->header_name_start = u->buffer.pos;
++    }
++
+     rc = ngx_http_parse_status_line(r, &u->buffer, status);
+ 
+     if (rc == NGX_AGAIN) {
+@@ -1029,6 +1033,7 @@ ngx_http_scgi_process_status_line(ngx_http_request_t *r)
+ 
+     if (rc == NGX_ERROR) {
+         u->process_header = ngx_http_scgi_process_header;
++        u->buffer.pos = r->header_name_start;
+         r->state = 0;
+         return ngx_http_scgi_process_header(r);
+     }
+diff --git a/src/http/modules/ngx_http_uwsgi_module.c b/src/http/modules/ngx_http_uwsgi_module.c
+index 93bcad7..749254f 100644
+--- a/src/http/modules/ngx_http_uwsgi_module.c
++++ b/src/http/modules/ngx_http_uwsgi_module.c
+@@ -1249,6 +1249,10 @@ ngx_http_uwsgi_process_status_line(ngx_http_request_t *r)
+ 
+     u = r->upstream;
+ 
++    if (r->state == 0) {
++        r->header_name_start = u->buffer.pos;
++    }
++
+     rc = ngx_http_parse_status_line(r, &u->buffer, status);
+ 
+     if (rc == NGX_AGAIN) {
+@@ -1257,6 +1261,7 @@ ngx_http_uwsgi_process_status_line(ngx_http_request_t *r)
+ 
+     if (rc == NGX_ERROR) {
+         u->process_header = ngx_http_uwsgi_process_header;
++        u->buffer.pos = r->header_name_start;
+         r->state = 0;
+         return ngx_http_uwsgi_process_header(r);
+     }
+-- 
+2.43.0
+

--- a/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
+++ b/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
@@ -11,6 +11,7 @@ SRC_URI:append = " \
                   file://CVE-2026-32647.patch \
                   file://CVE-2026-40701.patch \
                   file://CVE-2026-42934.patch \
+                  file://CVE-2026-42945.patch \
 "
 
 SRC_URI[sha256sum] = "77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d"

--- a/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
+++ b/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
@@ -12,6 +12,8 @@ SRC_URI:append = " \
                   file://CVE-2026-40701.patch \
                   file://CVE-2026-42934.patch \
                   file://CVE-2026-42945.patch \
+                  file://CVE-2026-42946-01.patch \
+                  file://CVE-2026-42946-02.patch \
 "
 
 SRC_URI[sha256sum] = "77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d"

--- a/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
+++ b/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
@@ -10,6 +10,7 @@ SRC_URI:append = " \
                   file://CVE-2026-28753.patch \
                   file://CVE-2026-32647.patch \
                   file://CVE-2026-40701.patch \
+                  file://CVE-2026-42934.patch \
 "
 
 SRC_URI[sha256sum] = "77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d"

--- a/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
+++ b/meta-webserver/recipes-httpd/nginx/nginx_1.24.0.bb
@@ -9,6 +9,7 @@ SRC_URI:append = " \
                   file://CVE-2026-27654.patch \
                   file://CVE-2026-28753.patch \
                   file://CVE-2026-32647.patch \
+                  file://CVE-2026-40701.patch \
 "
 
 SRC_URI[sha256sum] = "77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d"


### PR DESCRIPTION
merge: Currency merge with upstream scarthgap branch

Merge conlicts:
- Upstream updated firewalld from 1.3.2 to 1.3.4 while [we use 2.2.1](https://github.com/ni/meta-openembedded/commit/b6f1fd14a5c1a83d73d18e5a57e8eb31d2ac33b3)
    - I kept our changes

[AB#3738524](https://dev.azure.com/ni/DevCentral/_workitems/edit/3738524)

### Testing
- [X] Built packagefeed-ni-core, packagegroup-ni-desirable, package-index, and nilrt-base-system-image
- [X] Installed the built image on a cRIO-9033 and confirmed the device booted