### PR TITLE
minizip: Add minizip 1.3.2 to scarthgap

### DIFF
--- a/meta-oe/recipes-core/minizip/minizip/0001-Add-dependency-to-ints.h-in-minizip-Makefile.am.patch
+++ b/meta-oe/recipes-core/minizip/minizip/0001-Add-dependency-to-ints.h-in-minizip-Makefile.am.patch
@@ -1,0 +1,25 @@
+From cb14dc9ade3759352417a300e6c2ed73268f1d97 Mon Sep 17 00:00:00 2001
+From: Rui Chen <rui@chenrui.dev>
+Date: Tue, 17 Feb 2026 10:48:39 -0500
+Subject: [PATCH] Add dependency to ints.h in minizip Makefile.am.
+
+So that ints.h is part of the installation.
+
+Upstream-Status: Backport
+Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>
+---
+ contrib/minizip/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/contrib/minizip/Makefile.am b/contrib/minizip/Makefile.am
+index d343011..b7dea4f 100644
+--- a/contrib/minizip/Makefile.am
++++ b/contrib/minizip/Makefile.am
+@@ -27,6 +27,7 @@ libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
+ minizip_includedir = $(includedir)/minizip
+ minizip_include_HEADERS = \
+ 	crypt.h \
++	ints.h \
+ 	ioapi.h \
+ 	mztools.h \
+ 	unzip.h \

--- a/meta-oe/recipes-core/minizip/minizip_1.3.2.bb
+++ b/meta-oe/recipes-core/minizip/minizip_1.3.2.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Minizip Compression Library"
+DESCRIPTION = "Minizip is a general-purpose, patent-free, lossless data compression \
+library which is used by many different programs."
+HOMEPAGE = "http://www.winimage.com/zLibDll/minizip.html"
+SECTION = "libs"
+LICENSE = "Zlib"
+LIC_FILES_CHKSUM = "file://zip.h;beginline=14;endline=30;md5=b7d2930a7332b2bc68fc1a7fdc5ba775"
+
+GITHUB_BASE_URI ?= "https://github.com/madler/zlib/releases/"
+
+SRC_URI = "${GITHUB_BASE_URI}/download/v${PV}/zlib-${PV}.tar.xz \
+           file://0001-Add-dependency-to-ints.h-in-minizip-Makefile.am.patch;patchdir=../.. \
+           "
+
+S = "${WORKDIR}/zlib-${PV}/contrib/minizip"
+
+SRC_URI[sha256sum] = "d7a0654783a4da529d1bb793b7ad9c3318020af77667bcae35f95d0e42a792f3"
+
+PACKAGECONFIG ??= "demos"
+PACKAGECONFIG[demos] = "--enable-demos=yes,,,"
+
+RCONFLICTS:${PN} += "minizip-ng"
+
+DEPENDS = "zlib"
+
+inherit autotools github-releases
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
minizip was requested to be added as a resource for the Scarthgap distro

### Justification
[AB#3886002](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3886002)

Note: minizip 1.3.2 is available in wrynose and the same recipes were used here, with one change
- `S = "${UNPACKDIR}...` was changed to `S = "${WORKDIR}...` 

### Testing
- [x] `bitbake minizip` on x64
- [x] `bitbake minizip` on ARM