### PR TITLE
apache2: Upgrade apache2 from v2.4.67 to v2.4.68

### DIFF
--- a/meta-webserver/recipes-httpd/apache2/apache2_2.4.68.bb
+++ b/meta-webserver/recipes-httpd/apache2/apache2_2.4.68.bb
@@ -27,7 +27,7 @@ SRC_URI:append:class-target = " \
            "
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bddeddfac80b2c9a882241d008bb41c3"
-SRC_URI[sha256sum] = "66cd206637b0d5c446fa7dabe75fe03525da8fb55855876c46288cd88b136aa4"
+SRC_URI[sha256sum] = "68c74d4df38c26bed4dfbdb8f3baf1eb532f3872357becc1bba5d136f6b63c06"
 
 S = "${WORKDIR}/httpd-${PV}"
 


### PR DESCRIPTION
### Justification
apache2 v2.4.67 contains several high and critical CVEs that have been addressed in v2.4.68
[AB#3929063](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929063), [AB#3929094](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929094), [AB#3929102](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929102), [AB#3929145](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929145)
[AB#3929151](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929151), [AB#3929159](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929159), [AB#3929173](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929173)
[AB#3929140](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929140)
[AB#3929141](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929141)
[AB#3929177](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3929177)

### Summary
Updated `apache2` from v2.4.67 to v2.4.68

### Testing
- [x] bitbake `packagefeed-ni-core` x64 and arm
- [x] bitbake `package-index` x64 and arm
- [x] bitbake `nilrt-safemode-rootfs` x64
- [x] bitbake `nilrt-base-system-image` x64
- [x] Installed x64 BSI on a x64 target and verified it boots successfully
